### PR TITLE
[EDNA-43] Implement Upload service fully

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -19,3 +19,6 @@ Then run `make test` to execute tests.
 Run `stack exec -- edna-server -c dev-config.yaml` or `cabal run -- edna-server -c dev-config.yaml` depending on the build tool you used.
 * The server endpoints will be available at `http://localhost:9000/api/*`.
 * Swagger docs will be available at `http://localhost:9000/docs/`.
+
+Set `EDNA_DEBUG_DB=1` to enable logging of all DB actions made.
+It works in tests as well.

--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -111,6 +111,7 @@ test-suite edna-test
       Test.SMT.SMTSpec
       Test.SMT.State
       Test.SwaggerSpec
+      Test.UploadSpec
       Paths_edna
   hs-source-dirs:
       test
@@ -154,4 +155,5 @@ test-suite edna-test
     , QuickCheck
     , rio
     , servant-swagger
+    , unordered-containers
     , xlsx

--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -48,6 +48,7 @@ library
       Edna.ExperimentReader.Types
       Edna.Web.Types
       Edna.Upload.API
+      Edna.Upload.Error
       Edna.Upload.Service
       Edna.Util
   other-modules:

--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -37,6 +37,7 @@ library
       Edna.DB.Initialisation
       Edna.DB.Integration
       Edna.DB.Schema
+      Edna.Orphans
       Edna.Setup
       Edna.Web.API
       Edna.Web.Server

--- a/backend/sql/init.sql
+++ b/backend/sql/init.sql
@@ -27,14 +27,14 @@ create table if not exists target
 (
     target_id       serial      not null primary key,
     name            text        not null unique,
-    creation_date   timestamp   not null
+    creation_date   timestamp   not null default now()
 );
 
 create table if not exists compound
 (
     compound_id     serial          not null primary key,
     name            text            not null unique,
-    creation_date   timestamp       not null,
+    creation_date   timestamp       not null default now(),
     chemsoft_link   varchar(1000)   null
 );
 
@@ -45,12 +45,12 @@ create table if not exists compound
 -- it should be possible to download these files.
 create table if not exists experiment_file
 (
-    experiment_file_id serial not null primary key,
+    experiment_file_id serial    not null primary key,
     project_id         int       not null,
     methodology_id     int       null,  -- normally not null, but methodology can be removed
-    upload_date        timestamp not null,
+    upload_date        timestamp not null default now(),
     -- Arbitrary metadata from the file
-    meta               json      null,
+    meta               json      not null,
     -- Description provided from UI, it's like additional metadata
     -- that we store in a separate string
     description        text      not null,
@@ -132,8 +132,11 @@ create table if not exists analysis_method
     analysis_method_id serial not null primary key,
     description        text   null,
     -- Analysis-specific parameters
-    parameters         json   null
+    parameters         json   not null
 );
+
+-- Currently we have only one hardcoded analysis method.
+insert into analysis_method values (1, 'IC50', '[]'::json) on conflict do nothing;
 
 -- Sub-experiment is an experiment with disabled points.
 -- An experiment is a sub-experiment of itself with 0 disabled points.

--- a/backend/src/Edna/DB/Schema.hs
+++ b/backend/src/Edna/DB/Schema.hs
@@ -24,12 +24,16 @@ module Edna.DB.Schema
 
   , AnalysisMethodT (..)
   , AnalysisMethodRec
+  , theOnlyAnalysisMethod
+  , theOnlyAnalysisMethodId
 
   , SubExperimentT (..)
   , SubExperimentRec
 
   , RemovedMeasurementsT (..)
   , RemovedMeasurementsRec
+
+  , PrimaryKey (..)
 
   , EdnaSchema (..)
   , ednaSchema
@@ -38,9 +42,9 @@ module Edna.DB.Schema
 import Universum
 
 import Data.Time (LocalTime)
-import Database.Beam.Backend.SQL.BeamExtensions (SqlSerial)
+import Database.Beam.Backend.SQL.BeamExtensions (SqlSerial(..))
 import Database.Beam.Backend.Types (Nullable)
-import Database.Beam.Postgres (PgJSON, Postgres)
+import Database.Beam.Postgres (PgJSON(..), Postgres)
 import Database.Beam.Schema
   (Beamable, C, Database, DatabaseSettings, Table(..), TableEntity, defaultDbSettings)
 
@@ -159,7 +163,7 @@ data ExperimentFileT f = ExperimentFileRec
   , efProjectId :: C f Word32
   , efMethodologyId :: C (Nullable f) Word32
   , efUploadDate :: C f LocalTime
-  , efMeta :: C (Nullable f) (PgJSON FileMetadata)
+  , efMeta :: C f (PgJSON FileMetadata)
   , efDescription :: C f Text
   , efName :: C f Text
   , efContents :: C f LByteString
@@ -240,7 +244,7 @@ deriving stock instance Eq (PrimaryKey MeasurementT Identity)
 data AnalysisMethodT f = AnalysisMethodRec
   { amAnalysisMethodId :: C f (SqlSerial Word32)
   , amDescription :: C (Nullable f) Text
-  , amParameters :: C (Nullable f) (PgJSON ()) -- TODO add corresponding type
+  , amParameters :: C f (PgJSON ()) -- TODO add corresponding type
   } deriving stock Generic
     deriving anyclass Beamable
 
@@ -257,6 +261,20 @@ instance Table AnalysisMethodT where
 
 deriving stock instance Show (PrimaryKey AnalysisMethodT Identity)
 deriving stock instance Eq (PrimaryKey AnalysisMethodT Identity)
+
+-- | Currently we always have only one analysis method that is inserted upon
+-- initialization.
+theOnlyAnalysisMethod :: AnalysisMethodRec
+theOnlyAnalysisMethod = AnalysisMethodRec
+  { amAnalysisMethodId = 1
+  , amDescription = Just "IC50"
+  , amParameters = PgJSON ()
+  }
+
+-- | Currently we always have only one analysis method that is inserted upon
+-- initialization. This value is its ID.
+theOnlyAnalysisMethodId :: Word32
+theOnlyAnalysisMethodId = unSerial (amAnalysisMethodId theOnlyAnalysisMethod)
 
 --------------------------
 -- Sub-experiment

--- a/backend/src/Edna/ExperimentReader/Error.hs
+++ b/backend/src/Edna/ExperimentReader/Error.hs
@@ -9,6 +9,7 @@ import Data.Typeable (cast)
 import Fmt (Buildable(..), (+|), (|+))
 
 import Edna.ExperimentReader.Types (CellType, PointYX(..))
+import Edna.Web.Error (ToServerError(..))
 
 data ExperimentParsingError
   = forall a . Typeable a => UnexpectedCellType PointYX (CellType a) (Maybe CellValue)
@@ -17,7 +18,7 @@ data ExperimentParsingError
   | PlateStartNotFound
   | FileParsingError ParseError
   | NoConcentrationPlate
-  deriving anyclass Exception
+  deriving anyclass (Exception, ToServerError)
 
 deriving stock instance Show ExperimentParsingError
 instance Eq ExperimentParsingError where

--- a/backend/src/Edna/Orphans.hs
+++ b/backend/src/Edna/Orphans.hs
@@ -1,0 +1,13 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- | Orphan instances for types from other packages.
+
+module Edna.Orphans () where
+
+import Universum
+
+import RIO (RIO(..))
+
+-- It's also available in @rio-orphans@, but that would add extra dependencies,
+-- so it's simpler to just have one line for now.
+deriving newtype instance MonadCatch (RIO env)

--- a/backend/src/Edna/Setup.hs
+++ b/backend/src/Edna/Setup.hs
@@ -5,12 +5,16 @@ module Edna.Setup
   , EdnaContext (..)
   , edConfig
   , edConnectionPool
+  , edDebugDB
   ) where
 
 import Universum
 
+import qualified Data.Char as C
+
 import Lens.Micro.Platform (makeLenses)
 import RIO (RIO, runRIO)
+import System.Environment (lookupEnv)
 
 import Edna.Config.Definition (EdnaConfig(..))
 import Edna.DB.Connection (ConnPool(..), withPostgresConn)
@@ -18,17 +22,30 @@ import Edna.DB.Connection (ConnPool(..), withPostgresConn)
 data EdnaContext = EdnaContext
   { _edConfig :: !EdnaConfig
   , _edConnectionPool :: !ConnPool
+  , _edDebugDB :: !Bool
   }
 
 makeLenses ''EdnaContext
 
 type Edna = RIO EdnaContext
 
+-- | Create 'EdnaContext' and run 'Edna' action with this context.
 runEdna :: EdnaConfig -> Edna a -> IO a
 runEdna config action = do
   withPostgresConn config $ \pool -> do
+    debugDb <- askDebugDB
     let ednaContext = EdnaContext
           { _edConfig = config
           , _edConnectionPool = pool
+          , _edDebugDB = debugDb
           }
     runRIO ednaContext action
+
+-- If @EDNA_DEBUG_DB@ environment variable is set to @1@
+-- or @TRUE@ (case-insensitive), we will run postgres with
+-- debug logging.
+askDebugDB :: IO Bool
+askDebugDB = lookupEnv "EDNA_DEBUG_DB" <&> \case
+  Just "1"                       -> True
+  Just (map C.toLower -> "true") -> True
+  _                              -> False

--- a/backend/src/Edna/Upload/API.hs
+++ b/backend/src/Edna/Upload/API.hs
@@ -15,7 +15,7 @@ import Universum
 
 import Data.Aeson.TH (deriveJSON, deriveToJSON)
 import Data.Swagger (ToSchema(..))
-import Servant.API (Get, JSON, Post, ReqBody, Summary, (:>))
+import Servant.API (JSON, Post, ReqBody, Summary, (:>))
 import Servant.API.Generic (AsApi, ToServant, (:-))
 import Servant.Multipart (FileData(..), Mem, MultipartData(..), MultipartForm)
 import Servant.Server.Generic (AsServerT, genericServerT)
@@ -46,11 +46,13 @@ instance ToSchema FileUploadReq where
 -- | Endpoints necessary to implement file uploading.
 data FileUploadEndpoints route = FileUploadEndpoints
   { -- | Parse the file and return its summary for preview.
+    -- It doesn't change any state, but it's POST because GET can't
+    -- receive multipart.
     fueParseFile :: route
       :- "parse"
       :> Summary "Parse the file and return its summary for preview"
       :> MultipartForm Mem (MultipartData Mem)
-      :> Get '[JSON] FileSummary
+      :> Post '[JSON] FileSummary
 
   , -- | Upload the file with some methodology and project.
     fueUploadFile :: route

--- a/backend/src/Edna/Upload/API.hs
+++ b/backend/src/Edna/Upload/API.hs
@@ -23,9 +23,9 @@ import Servant.Server.Generic (AsServerT, genericServerT)
 import Edna.ExperimentReader.Parser (parseExperimentXls)
 import Edna.ExperimentReader.Types (FileContents(..), Measurement(..), TargetMeasurements(..))
 import Edna.Setup (Edna)
+import Edna.Upload.Error (UploadApiError(..))
 import Edna.Upload.Service (parseFile, uploadFile)
 import Edna.Util (ednaAesonWebOptions, gDeclareNamedSchema)
-import Edna.Web.Error (EdnaServerError(..))
 import Edna.Web.Types
 
 -- | Input data submitted along with uploaded file.
@@ -105,8 +105,7 @@ uploadExperiment :: MultipartData Mem -> Edna [ExperimentalMeasurement]
 uploadExperiment multipart = do
   (fileName, file) <- expectOneFile multipart
   putStrLn $ "Excel file name " ++ show fileName
-  fileContents <-
-    either (throwM . XlsxParingError) pure (parseExperimentXls file)
+  fileContents <- either throwM pure (parseExperimentXls file)
   let
     flatten :: (Text, TargetMeasurements) -> [ExperimentalMeasurement]
     flatten (targetName, TargetMeasurements targetMeasurements) =

--- a/backend/src/Edna/Upload/Error.hs
+++ b/backend/src/Edna/Upload/Error.hs
@@ -1,0 +1,43 @@
+-- | Errors that can happen during file upload.
+
+module Edna.Upload.Error
+  ( UploadError (..)
+  , UploadApiError (..)
+  ) where
+
+import Universum
+
+import Fmt (Buildable(..), pretty)
+
+import Edna.Web.Error (ToServerError(..))
+import Edna.Web.Types (Project, SqlId, TestMethodology)
+
+-- | Errors that can happen inside Upload service.
+data UploadError =
+    UEUnknownProject (SqlId Project)
+  | UEUnknownTestMethodology (SqlId TestMethodology)
+  deriving stock (Show, Eq)
+  deriving anyclass (ToServerError)
+
+instance Buildable UploadError where
+  build = \case
+    UEUnknownProject i -> "Unknown project: " <> build i
+    UEUnknownTestMethodology i -> "Unknown test methodology: " <> build i
+
+instance Exception UploadError where
+  displayException = pretty
+
+-- | Errors that can happen inside Upload API.
+data UploadApiError
+  = NoExperimentFileError
+  | TooManyExperimentFilesError
+  deriving stock (Show, Generic)
+  deriving anyclass (ToServerError)
+
+instance Buildable UploadApiError where
+  build = \case
+    NoExperimentFileError -> "Experiment file not attached"
+    TooManyExperimentFilesError -> "More than one experiment file attached"
+
+instance Exception UploadApiError where
+  displayException = pretty

--- a/backend/src/Edna/Upload/Service.hs
+++ b/backend/src/Edna/Upload/Service.hs
@@ -69,9 +69,9 @@ measurementsToSummary =
       HashMap Text FileSummaryItem -> (Text, TargetMeasurements) ->
       Edna $ HashMap Text FileSummaryItem
     step acc (targetName, TargetMeasurements targetMeasurements) = do
-      target <- maybeToLeft targetName <$> targetNameToId targetName
+      target <- NameAndId targetName <$> targetNameToId targetName
       compounds <- forM (keys targetMeasurements) $ \compoundName ->
-        maybeToLeft compoundName <$> compoundNameToId compoundName
+        NameAndId compoundName <$> compoundNameToId compoundName
       return $ acc & at targetName ?~ FileSummaryItem
         { fsiTarget = target
         , fsiCompounds = compounds

--- a/backend/src/Edna/Upload/Service.hs
+++ b/backend/src/Edna/Upload/Service.hs
@@ -20,7 +20,6 @@ import Database.Beam.Postgres (PgJSON(..), Postgres)
 import Database.Beam.Query
   (QExpr, all_, default_, guard_, insert, insertExpressions, insertValues, lookup_, select, val_,
   (==.))
-import Fmt (Buildable(..), pretty)
 import Lens.Micro.Platform (at, (?~))
 
 import Edna.DB.Integration
@@ -29,6 +28,7 @@ import Edna.DB.Schema as DB
 import Edna.ExperimentReader.Parser (parseExperimentXls)
 import Edna.ExperimentReader.Types as EReader
 import Edna.Setup
+import Edna.Upload.Error (UploadError(..))
 import Edna.Web.Types hiding (cName, tName)
 
 -- | Parse contents of an experiment data file and return as 'FileSummary'.
@@ -76,19 +76,6 @@ measurementsToSummary =
         { fsiTarget = target
         , fsiCompounds = compounds
         }
-
-data UploadError =
-    UEUnknownProject (SqlId Project)
-  | UEUnknownTestMethodology (SqlId TestMethodology)
-  deriving stock (Show, Eq)
-
-instance Buildable UploadError where
-  build = \case
-    UEUnknownProject i -> "Unknown project: " <> build i
-    UEUnknownTestMethodology i -> "Unknown test methodology: " <> build i
-
-instance Exception UploadError where
-  displayException = pretty
 
 -- | Parse an experiment data file and save it to DB.
 uploadFile ::

--- a/backend/src/Edna/Web/Handlers.hs
+++ b/backend/src/Edna/Web/Handlers.hs
@@ -1,8 +1,6 @@
 module Edna.Web.Handlers
   ( ednaHandlers
-  , EdnaServerError (..)
-  )
-where
+  ) where
 
 import Universum
 
@@ -16,7 +14,6 @@ import Edna.Setup (Edna)
 import Edna.Web.API
   (CompoundEndpoints(..), EdnaEndpoints(..), MethodologyEndpoints(..), ProjectEndpoints(..),
   TargetEndpoints(..))
-import Edna.Web.Error (EdnaServerError(..))
 
 type EdnaHandlers m = ToServant EdnaEndpoints (AsServerT m)
 

--- a/backend/src/Edna/Web/Server.hs
+++ b/backend/src/Edna/Web/Server.hs
@@ -47,7 +47,8 @@ ednaServer ctx = hoistServer ednaAPI (ednaToHandler ctx) ednaHandlers
 ednaToHandler :: EdnaContext -> Edna a -> Handler a
 ednaToHandler ctx action =
   runRIO ctx action
-  `catch` throwServant
+  `catch` throwServant -- catch 'EdnaServerError'
+  `catch` throwError   -- catch 'ServantError'
   where
     throwServant = throwError . toServerError @EdnaServerError
 

--- a/backend/src/Edna/Web/Server.hs
+++ b/backend/src/Edna/Web/Server.hs
@@ -17,10 +17,11 @@ import Edna.Config.Definition (acListenAddr, acServeDocs, ecApi)
 import Edna.Config.Utils (fromConfig)
 import Edna.DB.Initialisation (schemaInit)
 import Edna.Setup (Edna, EdnaContext)
+import Edna.Upload.Error (UploadApiError)
 import Edna.Util (NetworkAddress(..))
 import Edna.Web.API (EdnaAPI, ednaAPI)
 import Edna.Web.Error (toServerError)
-import Edna.Web.Handlers (EdnaServerError, ednaHandlers)
+import Edna.Web.Handlers (ednaHandlers)
 import Edna.Web.Swagger (ednaAPIWithDocs, ednaApiSwagger, withSwaggerUI)
 
 -- | Sets the given listen address in a Warp server settings.
@@ -50,7 +51,7 @@ ednaToHandler ctx action =
   `catch` throwServant -- catch 'EdnaServerError'
   `catch` throwError   -- catch 'ServantError'
   where
-    throwServant = throwError . toServerError @EdnaServerError
+    throwServant = throwError . toServerError @UploadApiError
 
 -- | Runs the web server which serves Edna API.
 edna :: Edna ()

--- a/backend/src/Edna/Web/Types.hs
+++ b/backend/src/Edna/Web/Types.hs
@@ -40,7 +40,7 @@ import Edna.Util (ednaAesonWebOptions, gDeclareNamedSchema, gToParamSchema)
 -- identified by this ID.
 newtype SqlId t = SqlId
   { unSqlId :: Word
-  } deriving stock (Generic, Show, Eq)
+  } deriving stock (Generic, Show, Eq, Ord)
     deriving newtype (FromHttpApiData, FromJSON, ToJSON, ToSchema, Hashable)
 
 instance Buildable (SqlId t) where
@@ -91,7 +91,7 @@ data FileSummaryItem = FileSummaryItem
   -- instead.
   , fsiCompounds :: [Either (SqlId Compound) Text]
   -- IDs of all compounds interacting with this target. Or names for new ones.
-  } deriving stock (Generic, Show, Eq)
+  } deriving stock (Generic, Show, Eq, Ord)
 
 -- | Project as submitted by end users.
 data Project = Project

--- a/backend/src/Edna/Web/Types.hs
+++ b/backend/src/Edna/Web/Types.hs
@@ -22,6 +22,7 @@ import Universum
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Aeson.TH (deriveJSON, deriveToJSON)
 import Data.Swagger (SwaggerType(..), ToParamSchema(..), ToSchema(..), enum_, type_)
+import Fmt (Buildable(..))
 import Lens.Micro ((?~))
 import Network.URI (URI(..))
 import Network.URI.JSON ()
@@ -40,7 +41,10 @@ import Edna.Util (ednaAesonWebOptions, gDeclareNamedSchema, gToParamSchema)
 newtype SqlId t = SqlId
   { unSqlId :: Word
   } deriving stock (Generic, Show, Eq)
-    deriving newtype (FromHttpApiData, FromJSON, ToJSON, ToSchema)
+    deriving newtype (FromHttpApiData, FromJSON, ToJSON, ToSchema, Hashable)
+
+instance Buildable (SqlId t) where
+  build (SqlId n) = "ID#" <> build n
 
 -- | This data type is useful when you want to return something with its ID.
 data WithId t = WithId
@@ -93,7 +97,7 @@ data FileSummaryItem = FileSummaryItem
 data Project = Project
   { pName :: Text
   , pDescription :: Text
-  } deriving stock (Generic, Show)
+  } deriving stock (Generic, Show, Eq)
 
 -- | Extra data about projects that is not submitted by users, but is stored
 -- in DB.
@@ -112,7 +116,7 @@ data TestMethodology = TestMethodology
   { tmName :: Text
   , tmDescription :: Text
   , tmConfluence :: URI
-  } deriving stock (Generic, Show)
+  } deriving stock (Generic, Show, Eq)
 
 -- | Compounds are not submitted directly by users, so for now
 -- there is only one representation for frontend.

--- a/backend/test/Test/DB/Gen.hs
+++ b/backend/test/Test/DB/Gen.hs
@@ -21,8 +21,8 @@ import Hedgehog.Range (constant)
 
 import Edna.DB.Schema
   (AnalysisMethodRec, AnalysisMethodT(..), CompoundRec, CompoundT(..), ExperimentFileRec,
-  ExperimentFileT(..), ExperimentRec, ExperimentT(..), MeasurementRec, MeasurementT(..),
-  ProjectRec, ProjectT(..), RemovedMeasurementsRec, RemovedMeasurementsT(..), SubExperimentRec,
+  ExperimentFileT(..), ExperimentRec, ExperimentT(..), MeasurementRec, MeasurementT(..), ProjectRec,
+  ProjectT(..), RemovedMeasurementsRec, RemovedMeasurementsT(..), SubExperimentRec,
   SubExperimentT(..), TargetRec, TargetT(..), TestMethodologyRec, TestMethodologyT(..))
 import Test.Gen
   (genByteString, genDescription, genDoubleSmallPrec, genFileMetadata, genLocalTime, genName,
@@ -59,7 +59,7 @@ genCompoundRec compoundId = do
 genExperimentFileRec :: Gen.MonadGen m => Word32 -> Word32 -> Word32 -> m ExperimentFileRec
 genExperimentFileRec experimentFileId efProjectId methodologyId = do
   efUploadDate <- genLocalTime
-  efMeta <- PgJSON <<$>> Gen.maybe genFileMetadata
+  efMeta <- PgJSON <$> genFileMetadata
   efDescription <- genDescription
   efName <- genName
   efContents <- genByteString
@@ -83,7 +83,7 @@ genMeasurementRec measurementId mExperimentId = do
 genAnalysisMethodRec :: Gen.MonadGen m => Word32 -> m AnalysisMethodRec
 genAnalysisMethodRec analysisMethodId = do
   amDescription <- Gen.maybe genDescription
-  amParameters <- PgJSON <<$>> Gen.maybe (pure ())
+  let amParameters = PgJSON ()
   pure AnalysisMethodRec {amAnalysisMethodId = SqlSerial analysisMethodId, ..}
 
 genSubExperimentRec :: Gen.MonadGen m => Word32 -> Word32 -> Word32 -> m SubExperimentRec

--- a/backend/test/Test/Gen.hs
+++ b/backend/test/Test/Gen.hs
@@ -14,6 +14,7 @@ module Test.Gen
   , genWithExtra
   , genStubSortBy
   , genFileUploadReq
+  , genNameAndId
   , genFileSummaryItem
   , genProject
   , genProjectExtra
@@ -93,13 +94,13 @@ genURI = do
 genFileUploadReq :: MonadGen m => m FileUploadReq
 genFileUploadReq = FileUploadReq <$> genSqlId <*> genSqlId <*> genDescription
 
+genNameAndId :: MonadGen m => m (NameAndId x)
+genNameAndId = NameAndId <$> genName <*> Gen.maybe genSqlId
+
 genFileSummaryItem :: MonadGen m => m FileSummaryItem
 genFileSummaryItem = do
-  let
-    genIdOrName :: MonadGen m => m (Either (SqlId x) Text)
-    genIdOrName = Gen.either genSqlId genName
-  compounds <- Gen.list (Range.linear 0 10) genIdOrName
-  FileSummaryItem <$> genIdOrName <*> pure compounds
+  compounds <- Gen.list (Range.linear 0 10) genNameAndId
+  FileSummaryItem <$> genNameAndId <*> pure compounds
 
 genProject :: MonadGen m => m Project
 genProject = Project <$> genName <*> genDescription
@@ -231,6 +232,9 @@ instance Arbitrary FileUploadReq where
   arbitrary = hedgehog genFileUploadReq
 
 deriving newtype instance Arbitrary FileSummary
+
+instance Arbitrary (NameAndId t) where
+  arbitrary = hedgehog genNameAndId
 
 instance Arbitrary FileSummaryItem where
   arbitrary = hedgehog genFileSummaryItem

--- a/backend/test/Test/Gen.hs
+++ b/backend/test/Test/Gen.hs
@@ -13,7 +13,6 @@ module Test.Gen
   , genWithId
   , genWithExtra
   , genStubSortBy
-  , genFileUploadReq
   , genNameAndId
   , genFileSummaryItem
   , genProject
@@ -49,7 +48,7 @@ import Test.QuickCheck.Hedgehog (hedgehog)
 
 import Edna.ExperimentReader.Types
   (FileContents(..), FileMetadata(..), Measurement(..), TargetMeasurements(..))
-import Edna.Upload.API (ExperimentalMeasurement(..), FileUploadReq(..))
+import Edna.Upload.API (ExperimentalMeasurement(..))
 import Edna.Web.Types
 
 ----------------
@@ -90,9 +89,6 @@ genURI = do
       , uriRegName = "www.leningrad.spb.ru"
       , uriPort = ":42"
       }
-
-genFileUploadReq :: MonadGen m => m FileUploadReq
-genFileUploadReq = FileUploadReq <$> genSqlId <*> genSqlId <*> genDescription
 
 genNameAndId :: MonadGen m => m (NameAndId x)
 genNameAndId = NameAndId <$> genName <*> Gen.maybe genSqlId
@@ -227,9 +223,6 @@ instance Arbitrary StubSortBy where
 
 instance Arbitrary URI where
   arbitrary = hedgehog genURI
-
-instance Arbitrary FileUploadReq where
-  arbitrary = hedgehog genFileUploadReq
 
 deriving newtype instance Arbitrary FileSummary
 

--- a/backend/test/Test/SMT/SMTSpec.hs
+++ b/backend/test/Test/SMT/SMTSpec.hs
@@ -22,7 +22,8 @@ import Edna.ExperimentReader.Types (FileContents(..), TargetMeasurements(..))
 import Edna.Orphans ()
 import Edna.Setup (EdnaContext)
 import Edna.Upload.Service (UploadError(..), parseFile', uploadFile')
-import Edna.Web.Types (FileSummary(..), FileSummaryItem(..), Project, SqlId(..), TestMethodology)
+import Edna.Web.Types
+  (FileSummary(..), FileSummaryItem(..), NameAndId(..), Project, SqlId(..), TestMethodology)
 
 import Test.Gen
 import Test.SMT.State
@@ -81,9 +82,9 @@ correctFileSummary oldState _ (ParseFile fileContents) fileSummary =
       HashMap Text FileSummaryItem -> (Text, TargetMeasurements) ->
       EdnaReader (HashMap Text FileSummaryItem)
     step acc (targetName, TargetMeasurements targetMeasurements) = do
-      target <- maybeToLeft targetName <$> targetNameToId targetName
+      target <- NameAndId targetName <$> targetNameToId targetName
       compounds <- forM (keys targetMeasurements) $ \compoundName ->
-        maybeToLeft compoundName <$> compoundNameToId compoundName
+        NameAndId compoundName <$> compoundNameToId compoundName
       return $ acc & at targetName ?~ FileSummaryItem
         { fsiTarget = target
         , fsiCompounds = compounds

--- a/backend/test/Test/SMT/SMTSpec.hs
+++ b/backend/test/Test/SMT/SMTSpec.hs
@@ -7,31 +7,38 @@ module Test.SMT.SMTSpec
 import Universum
 
 import Hedgehog
-  (Callback(..), Command(..), HTraversable(..), MonadGen, executeSequential, forAll, (===))
+  (Callback(..), Command(..), HTraversable(..), MonadGen, MonadTest, Var, annotate, assert,
+  executeSequential, failure, forAll, (===))
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import Lens.Micro.Platform (at, (?~))
+import Lens.Micro.Platform (at, (.=), (?~))
 import RIO (runRIO)
 import Test.Hspec (Spec, context, it)
-import Test.Hspec.Hedgehog (hedgehog)
+import Test.Hspec.Hedgehog (modifyMaxSuccess)
 
 import Edna.ExperimentReader.Types (FileContents(..), TargetMeasurements(..))
+import Edna.Orphans ()
 import Edna.Setup (EdnaContext)
-import Edna.Upload.Service (parseFile')
-import Edna.Web.Types (FileSummary(..), FileSummaryItem(..))
+import Edna.Upload.Service (UploadError(..), parseFile', uploadFile')
+import Edna.Web.Types (FileSummary(..), FileSummaryItem(..), Project, SqlId(..), TestMethodology)
 
 import Test.Gen
 import Test.SMT.State
-import Test.Setup (withContext)
+import Test.Setup (ednaTestMode, withContext)
 
 spec :: Spec
-spec = context "State machine tests" $ withContext $
-  it "Edna implementation matches Edna model" $ \ctx -> hedgehog $ do
+spec = context "State machine tests" $ withContext $ modifyMaxSuccess (min 20) $
+  it "Edna implementation matches Edna model" $ \ctx -> ednaTestMode ctx $ do
     actions <- forAll $
       Gen.sequential (Range.linear 1 100) initialState
         [ cmdParseFile ctx
+        , cmdUploadFile ctx
         ]
     executeSequential initialState actions
+
+----------------
+-- ParseFile
+----------------
 
 newtype ParseFile (v :: Type -> Type) = ParseFile FileContents
   deriving stock (Show, Eq)
@@ -44,7 +51,7 @@ cmdParseFile ::
 cmdParseFile ctx =
   let
     -- We can always parse a file, state doesn't matter.
-    gen _state = Just $ ParseFile <$> genFileContents
+    gen _state = Just $ ParseFile <$> genFileContents genName genName
     execute (ParseFile fileContents) =
       runRIO ctx $ parseFile' fileContents
 
@@ -79,3 +86,102 @@ correctFileSummary oldState _ (ParseFile fileContents) fileSummary =
         { fsiTarget = target
         , fsiCompounds = compounds
         }
+
+----------------
+-- UploadFile
+----------------
+
+data UploadFile (v :: Type -> Type) = UploadFile
+  { ufProject :: SqlId Project
+  , ufTestMethodology :: SqlId TestMethodology
+  , ufDescription :: Text
+  , ufFileName :: Text
+  , ufFileContents :: FileContents
+  }
+  deriving stock (Show, Eq)
+
+instance HTraversable UploadFile where
+  htraverse _ (UploadFile p tm d fn fc) = pure (UploadFile p tm d fn fc)
+
+-- If the list is not empty, generate one of its elements with high probability.
+-- If the list is empty or unlikely scenario happens, the provided generator
+-- will be used instead.
+genOneOfLikely :: MonadGen m => m a -> [a] -> m a
+genOneOfLikely genA as
+  | null as = genA
+  | otherwise = Gen.frequency [(1, genA), (10, Gen.element as)]
+
+cmdUploadFile ::
+  (MonadGen gen, MonadIO m) => EdnaContext -> Command gen m EdnaState
+cmdUploadFile ctx =
+  let
+    gen EdnaState {..} = Just do
+      -- It's not allowed to add a file not referring to an existing project and
+      -- test methodology.
+      -- We still generate such cases to check that an error happens, but
+      -- we try to generate valid cases because they are more interesting and
+      -- useful.
+      ufProject <- genOneOfLikely genSqlId $ keys _esProjects
+      ufTestMethodology <- genOneOfLikely genSqlId $ keys _esTestMethodologies
+      ufDescription <- genDescription
+      ufFileName <- genName
+      let genTargetName = genOneOfLikely genName $ keys _esTargetByName
+      let genCompoundName = genOneOfLikely genName $ keys _esCompoundByName
+      ufFileContents <- genFileContents genTargetName genCompoundName
+      return UploadFile {..}
+    execute UploadFile {..} =
+      liftIO $ try @_ @UploadError $
+      runRIO ctx $ uploadFile'
+        ufProject ufTestMethodology ufDescription ufFileName ufFileContents
+
+  in Command gen execute
+  [ Update applyUploadFile
+  -- We expect the same file summary as in @ParseFile@.
+  , Ensure $ \oldState newState uploadFile ->
+    either (const pass) $
+    correctFileSummary oldState newState (ParseFile $ ufFileContents uploadFile)
+  , Ensure failsOnUnknown
+  ]
+
+applyUploadFile ::
+  EdnaState v -> UploadFile v -> Var output v -> EdnaState v
+applyUploadFile es UploadFile {..} _ = executingState es $ runMaybeT $ do
+  projectState <- MaybeT $ use (esProjects . at ufProject)
+  let newProjectState =
+        projectState & psFiles %~ ((ufFileContents, ufTestMethodology):)
+  esProjects . at ufProject .= Just newProjectState
+  let
+    insertToBothMaps ::
+      Lens' (EdnaState v) (HashMap (SqlId x) Text) ->
+      Lens' (EdnaState v) (HashMap Text (SqlId x)) ->
+      Text -> State (EdnaState v) ()
+    insertToBothMaps mapToName mapFromName name =
+      whenNothingM_ (use $ mapFromName . at name) $ do
+        newId <- SqlId . fromIntegral . length <$> use mapFromName
+        mapFromName . at name .= Just newId
+        mapToName . at newId .= Just name
+  lift $ forM_ (toPairs $ fcMeasurements ufFileContents) $
+    \(targetName, TargetMeasurements targetMeasurements) -> do
+      insertToBothMaps esTargetToName esTargetByName targetName
+      mapM_ (insertToBothMaps esCompoundToName esCompoundByName) $
+        keys targetMeasurements
+
+-- Upload fails if one tries to pass an unknown project or test methodology.
+failsOnUnknown :: Ensure UploadFile (Either UploadError FileSummary)
+failsOnUnknown oldState _ uploadFile res = do
+  let proj = ufProject uploadFile
+  let method = ufTestMethodology uploadFile
+  let expectErr expectedErr = case res of
+        Right _ -> failedTest "unexpected success"
+        Left err -> expectedErr === err
+  case (oldState ^. esProjects . at proj, oldState ^. esTestMethodologies . at method) of
+    (Just _, Nothing) -> expectErr (UEUnknownTestMethodology method)
+    (Nothing, Just _) -> expectErr (UEUnknownProject proj)
+    (Nothing, Nothing) ->
+      assert $ res == Left (UEUnknownTestMethodology method)
+        || res == Left (UEUnknownProject proj)
+    (Just _, Just _) -> pass
+
+-- | A 'Property' that always fails with given message.
+failedTest :: (HasCallStack, MonadTest m) => Text -> m ()
+failedTest r = withFrozenCallStack $ annotate (toString r) >> failure

--- a/backend/test/Test/SMT/State.hs
+++ b/backend/test/Test/SMT/State.hs
@@ -2,10 +2,17 @@
 
 module Test.SMT.State
   ( EdnaState (..)
-  , esFiles
+  , esTargetToName
   , esTargetByName
+  , esCompoundToName
   , esCompoundByName
+  , esProjects
+  , esTestMethodologies
   , initialState
+
+  , ProjectState (..)
+  , psFiles
+  , psProject
 
   , Ensure
   , EdnaReader
@@ -17,26 +24,42 @@ import Hedgehog (Concrete, Test)
 import Lens.Micro.Platform (makeLenses)
 
 import Edna.ExperimentReader.Types (FileContents)
-import Edna.Web.Types (Compound, SqlId, Target)
+import Edna.Web.Types (Compound, Project, SqlId, Target, TestMethodology)
 
 -- It's currently incomplete (just like everything in this file),
 -- more data will be added later.
 data EdnaState (v :: Type -> Type) = EdnaState
-  { _esFiles :: HashMap Text FileContents
-  -- ^ All files uploaded so far.
+  { _esTargetToName :: HashMap (SqlId Target) Text
+  -- ^ Names and IDs of all targets added so far.
   , _esTargetByName :: HashMap Text (SqlId Target)
   -- ^ A way to quickly find target ID by its name.
+  , _esCompoundToName :: HashMap (SqlId Compound) Text
+  -- ^ Names and IDs of all compounds added so far.
   , _esCompoundByName :: HashMap Text (SqlId Compound)
   -- ^ A way to quickly find compound ID by its name.
+  , _esProjects :: HashMap (SqlId Project) ProjectState
+  -- ^ All projects added so far.
+  , _esTestMethodologies :: HashMap (SqlId TestMethodology) TestMethodology
+  -- ^ All test methodologies added so far.
+  } deriving stock (Show, Eq)
+
+-- | Data stored for each project.
+data ProjectState = ProjectState
+  { _psFiles :: [(FileContents, SqlId TestMethodology)]
+  , _psProject :: Project
   } deriving stock (Show, Eq)
 
 makeLenses ''EdnaState
+makeLenses ''ProjectState
 
 initialState :: EdnaState v
 initialState = EdnaState
-  { _esFiles = mempty
+  { _esTargetToName = mempty
   , _esTargetByName = mempty
+  , _esCompoundToName = mempty
   , _esCompoundByName = mempty
+  , _esProjects = mempty
+  , _esTestMethodologies = mempty
   }
 
 -- | Type of a predicate passed to @Ensure@ constructor.

--- a/backend/test/Test/Setup.hs
+++ b/backend/test/Test/Setup.hs
@@ -1,5 +1,6 @@
 module Test.Setup
   ( withContext
+  , runWithInit
   , ednaTestMode
   ) where
 
@@ -49,5 +50,9 @@ withContext = around withContext'
         ctx <- ask
         liftIO $ callback ctx
 
+-- | Drop existing DB, initialize it and then run given 'Edna' action.
+runWithInit :: EdnaContext -> Edna a -> IO a
+runWithInit ctx action = runRIO ctx $ schemaInit *> action
+
 ednaTestMode :: EdnaContext -> PropertyT Edna a -> PropertyT IO ()
-ednaTestMode ctx = void . hoist (\action -> runRIO ctx $ schemaInit *> action)
+ednaTestMode ctx = void . hoist (runWithInit ctx)

--- a/backend/test/Test/UploadSpec.hs
+++ b/backend/test/Test/UploadSpec.hs
@@ -14,7 +14,7 @@ import Test.Hspec (Spec, describe, it, shouldBe, shouldThrow, xit)
 import Edna.ExperimentReader.Types
   (FileContents(..), FileMetadata(..), Measurement(..), TargetMeasurements(..))
 import Edna.Upload.Service (UploadError(..), parseFile', uploadFile')
-import Edna.Web.Types (FileSummary(..), FileSummaryItem(..), SqlId(..))
+import Edna.Web.Types (FileSummary(..), FileSummaryItem(..), NameAndId(..), SqlId(..))
 
 import Test.Setup (runWithInit, withContext)
 
@@ -87,19 +87,25 @@ m5 = Measurement
   , mIsOutlier = True
   }
 
+newNAI :: Text -> NameAndId anything
+newNAI name = NameAndId name Nothing
+
 sampleFileSummary :: FileSummary
 sampleFileSummary = FileSummary
-  [ FileSummaryItem (Right "tar1") [Right "comp3", Right "comp2", Right "comp1"]
-  , FileSummaryItem (Right "tar2") [Right "comp2"]
-  , FileSummaryItem (Right "tar3") [Right "comp4", Right "comp1"]
+  [ FileSummaryItem (newNAI "tar1") [newNAI "comp3", newNAI "comp2", newNAI "comp1"]
+  , FileSummaryItem (newNAI "tar2") [newNAI "comp2"]
+  , FileSummaryItem (newNAI "tar3") [newNAI "comp4", newNAI "comp1"]
   ]
+
+oldNAI :: Word -> Text -> NameAndId anything
+oldNAI i name = NameAndId name (Just (SqlId i))
 
 sampleFileSummary2 :: FileSummary
 sampleFileSummary2 = FileSummary
-  [ FileSummaryItem (Left (SqlId 1))
-      [Left (SqlId 3), Left (SqlId 2), Left (SqlId 1)]
-  , FileSummaryItem (Left (SqlId 2)) [Left (SqlId 2)]
-  , FileSummaryItem (Left (SqlId 3)) [Left (SqlId 4), Left (SqlId 1)]
+  [ FileSummaryItem (oldNAI 1 "tar1")
+      [oldNAI 3 "tar3", oldNAI 2 "tar2", oldNAI 1 "tar1"]
+  , FileSummaryItem (oldNAI 2 "tar2") [oldNAI 2 "comp2"]
+  , FileSummaryItem (oldNAI 3 "tar3") [oldNAI 4 "tar4", oldNAI 1 "tar1"]
   ]
 
 sampleMetadata :: FileMetadata

--- a/backend/test/Test/UploadSpec.hs
+++ b/backend/test/Test/UploadSpec.hs
@@ -1,0 +1,109 @@
+-- | Tests for the Upload service.
+
+module Test.UploadSpec
+  ( spec
+  ) where
+
+import Universum
+
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.HashMap.Strict as HM
+
+import Test.Hspec (Spec, describe, it, shouldBe, shouldThrow, xit)
+
+import Edna.ExperimentReader.Types
+  (FileContents(..), FileMetadata(..), Measurement(..), TargetMeasurements(..))
+import Edna.Upload.Service (UploadError(..), parseFile', uploadFile')
+import Edna.Web.Types (FileSummary(..), FileSummaryItem(..), SqlId(..))
+
+import Test.Setup (runWithInit, withContext)
+
+spec :: Spec
+spec = withContext $ do
+  describe "parseFile'" $ do
+    it "returns empty summary for empty contents" $ \ctx -> do
+      summary <- runWithInit ctx $ parseFile' (FileContents mempty sampleMetadata)
+      summary `shouldBe` FileSummary []
+    it "returns correct summary for sample data" $ \ctx -> do
+      summary <- runWithInit ctx $ parseFile' sampleFile
+      sortSummary summary `shouldBe` sortSummary sampleFileSummary
+    -- TODO Need to be able to add projects and methodologies.
+    xit "returns IDs when data is known" $ \ctx -> do
+      summary <- runWithInit ctx $ uploadSampleFile >> parseFile' sampleFile
+      sortSummary summary `shouldBe` sortSummary sampleFileSummary2
+  describe "uploadFile'" $ do
+    it "fails when referenced project does not exist" $ \ctx -> do
+      runWithInit ctx uploadSampleFile `shouldThrow`
+        (== UEUnknownProject (SqlId 1))
+    xit "fails when referenced test methodology does not exist" $ \ctx -> do
+      runWithInit ctx uploadSampleFile `shouldThrow`
+        (== UEUnknownTestMethodology (SqlId 1))
+    xit "TODO: positive tests" $ \ctx ->
+      runWithInit ctx pass
+  where
+    uploadSampleFile =
+      uploadFile' (SqlId 1) (SqlId 1) "descr" "name" BSL.empty sampleFile
+
+sampleFile :: FileContents
+sampleFile = FileContents {..}
+  where
+    fcMeasurements = HM.fromList . map (second TargetMeasurements) $
+      [ ("tar1", targetMeasurements1)
+      , ("tar2", targetMeasurements2)
+      , ("tar3", targetMeasurements3)
+      ]
+    fcMetadata = sampleMetadata
+
+targetMeasurements1 :: HashMap Text [Measurement]
+targetMeasurements1 = HM.fromList
+  [ ("comp1", [m1, m2, m3])
+  , ("comp2", [m2, m4, m5])
+  , ("comp3", [m1, m3, m4])
+  ]
+
+targetMeasurements2 :: HashMap Text [Measurement]
+targetMeasurements2 = HM.fromList
+  [ ("comp2", [m1, m2, m5])
+  ]
+
+targetMeasurements3 :: HashMap Text [Measurement]
+targetMeasurements3 = HM.fromList
+  [ ("comp1", [m1, m5])
+  , ("comp4", [m3, m4, m5])
+  ]
+
+m1, m2, m3, m4, m5 :: Measurement
+m1 = Measurement
+  { mConcentration = 1.5
+  , mSignal = 200
+  , mIsOutlier = False
+  }
+m2 = m1 {mConcentration = 3, mSignal = 400}
+m3 = m1 {mConcentration = 6, mSignal = 600}
+m4 = m1 {mConcentration = 12, mSignal = 800}
+m5 = Measurement
+  { mConcentration = 6
+  , mSignal = 5000
+  , mIsOutlier = True
+  }
+
+sampleFileSummary :: FileSummary
+sampleFileSummary = FileSummary
+  [ FileSummaryItem (Right "tar1") [Right "comp3", Right "comp2", Right "comp1"]
+  , FileSummaryItem (Right "tar2") [Right "comp2"]
+  , FileSummaryItem (Right "tar3") [Right "comp4", Right "comp1"]
+  ]
+
+sampleFileSummary2 :: FileSummary
+sampleFileSummary2 = FileSummary
+  [ FileSummaryItem (Left (SqlId 1))
+      [Left (SqlId 3), Left (SqlId 2), Left (SqlId 1)]
+  , FileSummaryItem (Left (SqlId 2)) [Left (SqlId 2)]
+  , FileSummaryItem (Left (SqlId 3)) [Left (SqlId 4), Left (SqlId 1)]
+  ]
+
+sampleMetadata :: FileMetadata
+sampleMetadata = FileMetadata ["foo", "room", "mood"]
+
+sortSummary :: FileSummary -> FileSummary
+sortSummary (FileSummary lst) = FileSummary (sort lst)


### PR DESCRIPTION
## Description

1. Implemented `compoundNameToId` and `targetNameToId` used in `parseFile`, so now it's fully implemented.
2. Implemented `uploadFile`.
3. Added `UploadFile` to state machine tests.

## Related issue(s)

Resolves https://issues.serokell.io/issue/EDNA-43

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
