### PR TITLE
Add health check to edna-server

### DIFF
--- a/backend/src/Edna/Web/API.hs
+++ b/backend/src/Edna/Web/API.hs
@@ -9,8 +9,8 @@ module Edna.Web.API
 
 import Universum
 
-import Servant.API ((:>), JSON, Post, Summary)
-import Servant.API.Generic ((:-), AsApi, ToServant)
+import Servant.API (GetNoContent, JSON, Post, Summary, (:<|>), (:>))
+import Servant.API.Generic (AsApi, ToServant, (:-))
 import Servant.Multipart (Mem, MultipartData(..), MultipartForm)
 
 import qualified Edna.Upload.API as Upload
@@ -36,6 +36,8 @@ data EdnaEndpoints route = EdnaEndpoints
 -- | API type specification.
 type EdnaAPI =
   "api" :> ToServant EdnaEndpoints AsApi
+  :<|>
+  "health" :> Summary "Check the health of this server" :> GetNoContent
 
 ednaAPI :: Proxy EdnaAPI
 ednaAPI = Proxy

--- a/backend/src/Edna/Web/Server.hs
+++ b/backend/src/Edna/Web/Server.hs
@@ -11,7 +11,8 @@ import Universum
 
 import qualified Network.Wai.Handler.Warp as Warp
 import RIO (runRIO)
-import Servant (Application, Handler, Server, hoistServer, serve, throwError)
+import Servant
+  (Application, Handler, NoContent(..), Server, hoistServer, serve, throwError, (:<|>)(..))
 
 import Edna.Config.Definition (acListenAddr, acServeDocs, ecApi)
 import Edna.Config.Utils (fromConfig)
@@ -41,7 +42,8 @@ serveWeb addr app = do
 
 -- | Makes the @Server@ for Edna API, given 'EdnaContext'.
 ednaServer :: EdnaContext -> Server EdnaAPI
-ednaServer ctx = hoistServer ednaAPI (ednaToHandler ctx) ednaHandlers
+ednaServer ctx =
+  hoistServer ednaAPI (ednaToHandler ctx) (ednaHandlers :<|> pure NoContent)
 
 -- | Run 'Edna' action inside 'Handler' monad.
 --


### PR DESCRIPTION
## Description

Problem: sometimes we just want to check whether `edna-server` and
not involve any application logic into it.

Solution: apparently a quite standard solution is to have a `/health`
GET endpoint which returns 204. That's what we do here using `servant`.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-54

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

Changes only affect endpoints and currently we don't have infrastructure for this type of tests, we'll work on it later.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
