### PR TITLE
[EDNA-22] Add logging to backend

### DIFF
--- a/backend/dev-config.yaml
+++ b/backend/dev-config.yaml
@@ -15,3 +15,6 @@ db:
     # * "enable-with-drop" will run drop script before init
     mode: "enable"
     init-script: "./sql/init.sql"
+
+# Other possible values: 'Prod' and 'Nothing'.
+logging: Dev

--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -37,6 +37,7 @@ library
       Edna.DB.Initialisation
       Edna.DB.Integration
       Edna.DB.Schema
+      Edna.Logging
       Edna.Orphans
       Edna.Setup
       Edna.Web.API

--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -70,6 +70,7 @@ library
     beam-postgres,
     bytestring,
     containers,
+    data-default,
     fmt,
     microlens,
     microlens-platform,
@@ -90,6 +91,8 @@ library
     text,
     time,
     unordered-containers,
+    wai,
+    wai-extra,
     warp,
     xlsx
 

--- a/backend/src/Edna/Config/Definition.hs
+++ b/backend/src/Edna/Config/Definition.hs
@@ -60,7 +60,7 @@ data LoggingConfig =
   -- ^ Production logging mode: log less than in development mode.
   | LogNothing
   -- ^ No logging.
-  deriving stock (Generic, Show)
+  deriving stock (Generic, Show, Eq)
 
 loggingConfigAesonOptions :: Aeson.Options
 loggingConfigAesonOptions = Aeson.defaultOptions

--- a/backend/src/Edna/Config/Definition.hs
+++ b/backend/src/Edna/Config/Definition.hs
@@ -9,6 +9,7 @@ module Edna.Config.Definition
   , EdnaConfig (..)
   , ecApi
   , ecDb
+  , ecLogging
 
   , ApiConfig (..)
   , acListenAddr
@@ -22,10 +23,13 @@ module Edna.Config.Definition
   , dbConnString
   , dbMaxConnections
   , dbInitialisation
+
+  , LoggingConfig (..)
   ) where
 
 import Universum
 
+import qualified Data.Aeson as Aeson
 import Data.Aeson.TH (deriveJSON)
 import Lens.Micro.Platform (makeLenses)
 import Text.Read (read)
@@ -48,10 +52,33 @@ data DbConfig = DbConfig
   , _dbInitialisation :: Maybe DbInit
   } deriving stock (Generic, Show)
 
+-- | Specification of how much to log.
+data LoggingConfig =
+    LogDev
+  -- ^ Development logging mode: log a lot.
+  | LogProd
+  -- ^ Production logging mode: log less than in development mode.
+  | LogNothing
+  -- ^ No logging.
+  deriving stock (Generic, Show)
+
+loggingConfigAesonOptions :: Aeson.Options
+loggingConfigAesonOptions = Aeson.defaultOptions
+  { Aeson.sumEncoding = Aeson.UntaggedValue
+  , Aeson.constructorTagModifier = drop 3
+  }
+
+instance Aeson.FromJSON LoggingConfig where
+  parseJSON = Aeson.genericParseJSON loggingConfigAesonOptions
+
+instance Aeson.ToJSON LoggingConfig where
+  toEncoding = Aeson.genericToEncoding loggingConfigAesonOptions
+
 data EdnaConfig = EdnaConfig
   { _ecApi :: ApiConfig
   , _ecDb :: DbConfig
-} deriving stock (Generic, Show)
+  , _ecLogging :: LoggingConfig
+  } deriving stock (Generic, Show)
 
 defaultEdnaConfig :: EdnaConfig
 defaultEdnaConfig = EdnaConfig
@@ -64,6 +91,7 @@ defaultEdnaConfig = EdnaConfig
     , _dbMaxConnections = 200
     , _dbInitialisation = Nothing
     }
+  , _ecLogging = LogProd
   }
 
 ---------------------------------------------------------------------------

--- a/backend/src/Edna/Logging.hs
+++ b/backend/src/Edna/Logging.hs
@@ -1,0 +1,25 @@
+-- | Logging primitives.
+
+module Edna.Logging
+  ( logDebug
+  , logMessage
+  ) where
+
+import Universum
+
+import Edna.Config.Definition (LoggingConfig(..), ecLogging)
+import Edna.Config.Utils (fromConfig)
+import Edna.Setup (Edna)
+
+-- | Log a debug message with low severity, only in development logging mode.
+logDebug :: Text -> Edna ()
+logDebug = logImpl (== LogDev)
+
+-- | Log a really useful message, unless logging is disabled.
+logMessage :: Text -> Edna ()
+logMessage = logImpl (/= LogNothing)
+
+logImpl :: (LoggingConfig -> Bool) -> Text -> Edna ()
+logImpl cond msg = do
+  lc <- fromConfig ecLogging
+  when (cond lc) $ hPutStrLn stderr msg


### PR DESCRIPTION
## Description

1. Added `wai-extra`'s middleware to log HTTP requests.
2. Add `logDebug` and `logMessage` functions to log arbitrary messages.

## Related issue(s)

https://issues.serokell.io/issue/EDNA-22

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

No tests, but I've tested it manually.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
