### PR TITLE
[EDNA-49] Export OCI images to GHCR

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,3 +46,9 @@ steps:
     commands:
       - nix-shell --run 'deploy .#jishui'
     branches: "demo"
+  - label: Push backend image to registry
+    commands:
+      - nix-shell --run 'scripts/docker-push.sh docker-archive:$(nix-build -A packages.x86_64-linux.docker-backend) docker://ghcr.io/serokell/edna-backend:latest'
+  - label: Push frontend image to registry
+    commands:
+      - nix-shell --run 'scripts/docker-push.sh docker-archive:$(nix-build -A packages.x86_64-linux.docker-frontend) docker://ghcr.io/serokell/edna-frontend:latest'

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,7 @@
         buildInputs = with pkgs.haskellPackages; [
           cabal-install hpack hlint self.packages.${system}.stack2cabal
           deploy-rs.defaultPackage.${system}
+          pkgs.skopeo
         ];
       };
     }));

--- a/scripts/docker-push.sh
+++ b/scripts/docker-push.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+skopeo copy --dest-creds=serokell-bot:"$GITHUB_TOKEN" "$@"


### PR DESCRIPTION
Images are pushed from `master`, and are available here: https://github.com/orgs/serokell/packages

Both packages (images) are linked to this repository, and their pages show the readme from this repo, contributors, etc. Anonymous access is enabled.

A new PAT was provisioned for `serokell-bot` with only package read/write access, and made available to the BK pipeline for this repository via environment variable `$GITHUB_TOKEN`.