### PR TITLE
[EDNA-42] Fix URI parsing

### DIFF
--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -120,6 +120,7 @@ test-suite edna-test
       Test.SMT.State
       Test.SwaggerSpec
       Test.UploadSpec
+      Test.Util.URISpec
       Paths_edna
   hs-source-dirs:
       test
@@ -144,7 +145,8 @@ test-suite edna-test
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:
-      beam-core
+      aeson
+    , beam-core
     , beam-postgres
     , bytestring
     , containers

--- a/backend/src/Edna/Util/URI.hs
+++ b/backend/src/Edna/Util/URI.hs
@@ -16,6 +16,9 @@ renderURI = show
 
 -- | Parse 'URI' from the format we use to communicate with outer world.
 --
--- TODO: is 'URI.parseURI' the right function? There are other parsing functions.
+-- Currently parsing logic is very permissive and accepts absolute and relative
+-- URIs with optional fragment identifier.
+-- So even empty URI is permitted.
+-- We can make it stricter later if we want.
 parseURI :: Text -> Maybe URI
-parseURI = URI.parseURI . toString
+parseURI = URI.parseURIReference . toString

--- a/backend/test/Test/Gen.hs
+++ b/backend/test/Test/Gen.hs
@@ -41,7 +41,7 @@ import qualified Hedgehog.Range as Range
 import Data.Time (LocalTime(..), fromGregorian, secondsToDiffTime, timeToTimeOfDay)
 import Hedgehog (MonadGen)
 import Lens.Micro (at, (?~))
-import Network.URI (URIAuth(..))
+import Network.URI (URIAuth(..), nullURI)
 import Test.QuickCheck (Arbitrary(..))
 import Test.QuickCheck.Hedgehog (hedgehog)
 
@@ -73,18 +73,18 @@ genDescription :: MonadGen m => m Text
 genDescription = Gen.text (Range.linear 5 200) Gen.unicode
 
 genURI :: forall m. MonadGen m => m URI
-genURI = do
+genURI = Gen.choice . (:[pure nullURI]) $ do
   uriScheme <- Gen.element ["http:", "ftp:"]
   uriAuthority <- Gen.maybe genURIAuth
-  uriPath <- Gen.element ["", "aaa", "bbb", "ccc"]
-  uriQuery <- Gen.element ["", "query", "foo"]
-  uriFragment <- Gen.element ["", "frag", "bar"]
+  uriPath <- Gen.element ["/aaa", "/bbb", "/ccc"]
+  uriQuery <- Gen.element ["?query", "?foo"]
+  uriFragment <- Gen.element ["#frag", "#bar"]
   return URI {..}
   where
     -- doesn't matter for our needs
     genURIAuth :: m URIAuth
     genURIAuth = pure URIAuth
-      { uriUserInfo = "edna"
+      { uriUserInfo = "edna@"
       , uriRegName = "www.leningrad.spb.ru"
       , uriPort = ":42"
       }

--- a/backend/test/Test/Util/URISpec.hs
+++ b/backend/test/Test/Util/URISpec.hs
@@ -1,0 +1,35 @@
+-- | Tests for @Edna.Util.URI@.
+
+module Test.Util.URISpec
+  ( spec
+  ) where
+
+import Universum
+
+import qualified Data.Aeson as Aeson
+import Hedgehog (forAll, test, tripping)
+import Network.URI (URI, nullURI)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+import Test.Hspec.Hedgehog (hedgehog)
+
+import Edna.Util.URI (parseURI, renderURI)
+
+import Test.Gen (genURI)
+
+spec :: Spec
+spec = do
+  describe "parseURI" $ do
+    it "accepts empty URI" $
+      parseURI "" `shouldBe` Just nullURI
+    it "accepts relative URI" $ do
+      parseURI "foo.bar" `shouldSatisfy` isJust
+      parseURI "foo" `shouldSatisfy` isJust
+    it "is reverse for 'renderURI'" $ hedgehog $ do
+      uri <- forAll genURI
+      test $ tripping uri renderURI parseURI
+  describe "JSON parsing" $ do
+    it "accepts empty URI" $
+      Aeson.decode "\"\"" `shouldBe` Just nullURI
+    it "accepts relative URI" $ do
+      Aeson.decode @URI "\"foo.bar\"" `shouldSatisfy` isJust
+      Aeson.decode @URI "\"foo\"" `shouldSatisfy` isJust


### PR DESCRIPTION
## Description

Our `parseURI` was inconsistent with `parseJSON`, this PR fixes this problem and adds some tests.

## Related issue(s)

https://issues.serokell.io/issue/EDNA-42

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
