### PR TITLE
[EDNA-62] Remove /api prefix from enda-server

### DIFF
--- a/backend/src/Edna/Web/API.hs
+++ b/backend/src/Edna/Web/API.hs
@@ -35,7 +35,7 @@ data EdnaEndpoints route = EdnaEndpoints
 
 -- | API type specification.
 type EdnaAPI =
-  "api" :> ToServant EdnaEndpoints AsApi
+  ToServant EdnaEndpoints AsApi
   :<|>
   "health" :> Summary "Check the health of this server" :> GetNoContent
 

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -18,10 +18,11 @@ module.exports = merge(common, {
 
     // Redirect api requests to the backend
     proxy: {
-      "/api": {
-        target: "http://localhost:9000"
-      }
-    }
+      '/api': {
+        target: 'http://localhost:9000',
+        pathRewrite: { '^/api': '' },
+      },
+    },
 
     // Uncomment in case of some troubles to inspect whether dev server generates bundles
     // writeToDisk: true,


### PR DESCRIPTION
## Description

Problem: in production deployment there is additional /api
prefix for edna-server. But frontend calls it with one `/api`.

Solution: change baseURL to `/api/api`. Update webpack config
to drop one `/api` so that local deployment still works.

## Related issue(s)

https://issues.serokell.io/issue/EDNA-62

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

No tests, currently we don't infra for that.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
