### PR TITLE
[EDNA-22] Another logging approach

### DIFF
--- a/backend/cabal.project
+++ b/backend/cabal.project
@@ -5,6 +5,11 @@ with-compiler: ghc-8.10.3
 packages:
     ./
 
+source-repository-package
+    type: git
+    location: git@github.com:serokell/servant-util.git
+    tag: 3dff2de34cce90c4d1dab68e03d30f8939fd52ca
+    subdir: servant-util
 
 allow-older: *
 allow-newer: *

--- a/backend/dev-config.yaml
+++ b/backend/dev-config.yaml
@@ -15,3 +15,6 @@ db:
     # * "enable-with-drop" will run drop script before init
     mode: "enable"
     init-script: "./sql/init.sql"
+
+# Other possible values: 'Prod' and 'Nothing'.
+logging: Dev

--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -70,6 +70,7 @@ library
     beam-postgres,
     bytestring,
     containers,
+    data-default,
     fmt,
     microlens,
     microlens-platform,
@@ -91,6 +92,8 @@ library
     text,
     time,
     unordered-containers,
+    wai,
+    wai-extra,
     warp,
     xlsx
 

--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -37,6 +37,7 @@ library
       Edna.DB.Initialisation
       Edna.DB.Integration
       Edna.DB.Schema
+      Edna.Logging
       Edna.Orphans
       Edna.Setup
       Edna.Web.API

--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -85,6 +85,7 @@ library
     servant-swagger,
     servant-swagger-ui-core,
     servant-swagger-ui,
+    servant-util,
     split,
     swagger2,
     text,

--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -120,6 +120,7 @@ test-suite edna-test
       Test.SMT.State
       Test.SwaggerSpec
       Test.UploadSpec
+      Test.Util.URISpec
       Paths_edna
   hs-source-dirs:
       test
@@ -144,7 +145,8 @@ test-suite edna-test
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:
-      beam-core
+      aeson
+    , beam-core
     , beam-postgres
     , bytestring
     , containers

--- a/backend/src/Edna/Config/Definition.hs
+++ b/backend/src/Edna/Config/Definition.hs
@@ -60,7 +60,7 @@ data LoggingConfig =
   -- ^ Production logging mode: log less than in development mode.
   | LogNothing
   -- ^ No logging.
-  deriving stock (Generic, Show)
+  deriving stock (Generic, Show, Eq)
 
 loggingConfigAesonOptions :: Aeson.Options
 loggingConfigAesonOptions = Aeson.defaultOptions

--- a/backend/src/Edna/Config/Definition.hs
+++ b/backend/src/Edna/Config/Definition.hs
@@ -9,6 +9,7 @@ module Edna.Config.Definition
   , EdnaConfig (..)
   , ecApi
   , ecDb
+  , ecLogging
 
   , ApiConfig (..)
   , acListenAddr
@@ -22,10 +23,13 @@ module Edna.Config.Definition
   , dbConnString
   , dbMaxConnections
   , dbInitialisation
+
+  , LoggingConfig (..)
   ) where
 
 import Universum
 
+import qualified Data.Aeson as Aeson
 import Data.Aeson.TH (deriveJSON)
 import Lens.Micro.Platform (makeLenses)
 import Text.Read (read)
@@ -48,10 +52,33 @@ data DbConfig = DbConfig
   , _dbInitialisation :: Maybe DbInit
   } deriving stock (Generic, Show)
 
+-- | Specification of how much to log.
+data LoggingConfig =
+    LogDev
+  -- ^ Development logging mode: log a lot.
+  | LogProd
+  -- ^ Production logging mode: log less than in development mode.
+  | LogNothing
+  -- ^ No logging.
+  deriving stock (Generic, Show)
+
+loggingConfigAesonOptions :: Aeson.Options
+loggingConfigAesonOptions = Aeson.defaultOptions
+  { Aeson.sumEncoding = Aeson.UntaggedValue
+  , Aeson.constructorTagModifier = drop 3
+  }
+
+instance Aeson.FromJSON LoggingConfig where
+  parseJSON = Aeson.genericParseJSON loggingConfigAesonOptions
+
+instance Aeson.ToJSON LoggingConfig where
+  toEncoding = Aeson.genericToEncoding loggingConfigAesonOptions
+
 data EdnaConfig = EdnaConfig
   { _ecApi :: ApiConfig
   , _ecDb :: DbConfig
-} deriving stock (Generic, Show)
+  , _ecLogging :: LoggingConfig
+  } deriving stock (Generic, Show)
 
 defaultEdnaConfig :: EdnaConfig
 defaultEdnaConfig = EdnaConfig
@@ -64,6 +91,7 @@ defaultEdnaConfig = EdnaConfig
     , _dbMaxConnections = 200
     , _dbInitialisation = Nothing
     }
+  , _ecLogging = LogProd
   }
 
 ---------------------------------------------------------------------------

--- a/backend/src/Edna/Library/Service.hs
+++ b/backend/src/Edna/Library/Service.hs
@@ -30,6 +30,7 @@ import Edna.Library.DB.Schema
 import Edna.Library.Error (LibraryError(..))
 import Edna.Library.Web.Types
   (CompoundResp(..), MethodologyReqResp(..), ProjectReq(..), ProjectResp, TargetResp)
+import Edna.Logging (logMessage)
 import Edna.Setup (Edna)
 import Edna.Util (IdType(..), SqlId(..), ensureOrThrow, justOrThrow, nothingOrThrow)
 import Edna.Util.URI (parseURI, renderURI)
@@ -99,7 +100,8 @@ getMethodologies _ _ _ = Q.getMethodologies >>= mapM methodologyToResp
 addMethodology :: MethodologyReqResp -> Edna (WithId 'MethodologyId MethodologyReqResp)
 addMethodology tm@MethodologyReqResp{..} = do
   Q.getMethodologyByName mrpName >>= nothingOrThrow (LEMethodologyNameExists mrpName)
-  Q.insertMethodology tm >>= methodologyToResp
+  res <- Q.insertMethodology tm >>= methodologyToResp
+  res <$ logMessage ("Added methodology with name " <> mrpName)
 
 updateMethodology
   :: SqlId 'MethodologyId
@@ -128,6 +130,7 @@ addProject :: ProjectReq -> Edna (WithId 'ProjectId ProjectResp)
 addProject p@ProjectReq{..} = do
   Q.getProjectByName prqName >>= nothingOrThrow (LEProjectNameExists prqName)
   ProjectRec{..} <- Q.insertProject p
+  logMessage $ "Added project with name " <> prqName
   getProject $ SqlId $ unSerial pProjectId
 
 updateProject

--- a/backend/src/Edna/Logging.hs
+++ b/backend/src/Edna/Logging.hs
@@ -1,0 +1,25 @@
+-- | Logging primitives.
+
+module Edna.Logging
+  ( logDebug
+  , logMessage
+  ) where
+
+import Universum
+
+import Edna.Config.Definition (LoggingConfig(..), ecLogging)
+import Edna.Config.Utils (fromConfig)
+import Edna.Setup (Edna)
+
+-- | Log a debug message with low severity, only in development logging mode.
+logDebug :: Text -> Edna ()
+logDebug = logImpl (== LogDev)
+
+-- | Log a really useful message, unless logging is disabled.
+logMessage :: Text -> Edna ()
+logMessage = logImpl (/= LogNothing)
+
+logImpl :: (LoggingConfig -> Bool) -> Text -> Edna ()
+logImpl cond msg = do
+  lc <- fromConfig ecLogging
+  when (cond lc) $ hPutStrLn stderr msg

--- a/backend/src/Edna/Orphans.hs
+++ b/backend/src/Edna/Orphans.hs
@@ -6,8 +6,27 @@ module Edna.Orphans () where
 
 import Universum
 
+import Fmt (Buildable(..), (+|), (|+))
 import RIO (RIO(..))
+import Servant.Multipart (MultipartData(..), MultipartForm')
+import Servant.Util.Combinators.Logging (ApiCanLogArg)
+import Servant.Util.Common.Common (ApiHasArgClass(..))
 
 -- It's also available in @rio-orphans@, but that would add extra dependencies,
 -- so it's simpler to just have one line for now.
 deriving newtype instance MonadCatch (RIO env)
+
+----------------
+-- Logging
+----------------
+
+instance ApiHasArgClass (MultipartForm' mods tag (MultipartData tag)) where
+  type ApiArg (MultipartForm' mods tag (MultipartData tag)) = MultipartData tag
+  apiArgName _ = "multipart"
+
+instance ApiCanLogArg (MultipartForm' mods tag (MultipartData tag))
+
+instance Buildable (MultipartData tag) where
+  build MultipartData {..} =
+    "multipart with " +| length inputs |+
+    " inputs and " +| length files |+ " files"

--- a/backend/src/Edna/Upload/API.hs
+++ b/backend/src/Edna/Upload/API.hs
@@ -14,10 +14,12 @@ import Universum
 
 import Data.Aeson.TH (deriveToJSON)
 import Data.Swagger (ToSchema(..))
+import Fmt (Buildable(..))
 import Servant.API (Capture, JSON, Post, QueryParam, Summary, (:>))
 import Servant.API.Generic (AsApi, ToServant, (:-))
 import Servant.Multipart (FileData(..), Mem, MultipartData(..), MultipartForm)
 import Servant.Server.Generic (AsServerT, genericServerT)
+import Servant.Util.Combinators.Logging (ForResponseLog(..))
 
 import Edna.ExperimentReader.Parser (parseExperimentXls)
 import Edna.ExperimentReader.Types (FileContents(..), Measurement(..), TargetMeasurements(..))
@@ -82,6 +84,9 @@ data ExperimentalMeasurement = ExperimentalMeasurement
   , emSignal :: Double
   , emOutlier :: Bool
   } deriving stock (Generic, Show, Eq)
+
+instance Buildable (ForResponseLog [ExperimentalMeasurement]) where
+  build _ = "LEGACY ExperimentalMeasurement"
 
 deriveToJSON ednaAesonWebOptions ''ExperimentalMeasurement
 

--- a/backend/src/Edna/Util/URI.hs
+++ b/backend/src/Edna/Util/URI.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 -- | Utilities to work with 'URI'.
 
 module Edna.Util.URI
@@ -7,12 +9,16 @@ module Edna.Util.URI
 
 import Universum
 
+import Fmt (Buildable(..))
 import Network.URI (URI)
 import qualified Network.URI as URI
 
 -- | Render 'URI' in the way we use to communicate with outer world.
 renderURI :: URI -> Text
 renderURI = show
+
+instance Buildable URI where
+  build = build . renderURI
 
 -- | Parse 'URI' from the format we use to communicate with outer world.
 --

--- a/backend/src/Edna/Util/URI.hs
+++ b/backend/src/Edna/Util/URI.hs
@@ -16,6 +16,9 @@ renderURI = show
 
 -- | Parse 'URI' from the format we use to communicate with outer world.
 --
--- TODO: is 'URI.parseURI' the right function? There are other parsing functions.
+-- Currently parsing logic is very permissive and accepts absolute and relative
+-- URIs with optional fragment identifier.
+-- So even empty URI is permitted.
+-- We can make it stricter later if we want.
 parseURI :: Text -> Maybe URI
-parseURI = URI.parseURI . toString
+parseURI = URI.parseURIReference . toString

--- a/backend/src/Edna/Web/Swagger.hs
+++ b/backend/src/Edna/Web/Swagger.hs
@@ -13,6 +13,7 @@ module Edna.Web.Swagger
   , module Exports
 
   -- Edna specific
+  , EdnaAPIWithDocs
   , ednaApiSwagger
   , ednaAPIWithDocs
   ) where
@@ -27,7 +28,7 @@ import Data.Swagger.Lens as Exports
 import Lens.Micro ((?~))
 import Lens.Micro.Platform (zoom, (.=), (?=))
 import Network.URI (URI)
-import Servant ((:<|>)(..), Server)
+import Servant (Server, (:<|>)(..))
 import Servant.API ((:>))
 import Servant.Multipart (MultipartData(..), MultipartForm)
 import Servant.Swagger (HasSwagger(..))

--- a/backend/stack.yaml
+++ b/backend/stack.yaml
@@ -27,6 +27,15 @@ extra-deps:
 - dependent-sum-0.7.1.0
 - constraints-extras-0.3.0.2
 - network-uri-json-0.4.0.0
+# servant-util is in dirty state and is not on Hackage.
+# Perhaps it should be renamed and maybe even split into multiple packages
+# with more precise goals.
+# It's developed by us, so we are quite confident in it, that's why we are using
+# it even though it's not ready yet.
+- git: git@github.com:serokell/servant-util.git
+  commit: 3dff2de34cce90c4d1dab68e03d30f8939fd52ca # not master
+  subdirs:
+    - servant-util
 
 # beam-core currently doesn't support aeson from the resolver we are using
 allow-newer: true

--- a/backend/test/Test/Gen.hs
+++ b/backend/test/Test/Gen.hs
@@ -41,7 +41,7 @@ import qualified Hedgehog.Range as Range
 import Data.Time (LocalTime(..), fromGregorian, secondsToDiffTime, timeToTimeOfDay)
 import Hedgehog (MonadGen)
 import Lens.Micro (at, (?~))
-import Network.URI (URIAuth(..))
+import Network.URI (URIAuth(..), nullURI)
 import Test.QuickCheck (Arbitrary(..))
 import Test.QuickCheck.Hedgehog (hedgehog)
 
@@ -73,18 +73,18 @@ genDescription :: MonadGen m => m Text
 genDescription = Gen.text (Range.linear 5 200) Gen.unicode
 
 genURI :: forall m. MonadGen m => m URI
-genURI = do
+genURI = Gen.choice . (:[pure nullURI]) $ do
   uriScheme <- Gen.element ["http:", "ftp:"]
   uriAuthority <- Gen.maybe genURIAuth
-  uriPath <- Gen.element ["", "aaa", "bbb", "ccc"]
-  uriQuery <- Gen.element ["", "query", "foo"]
-  uriFragment <- Gen.element ["", "frag", "bar"]
+  uriPath <- Gen.element ["/aaa", "/bbb", "/ccc"]
+  uriQuery <- Gen.element ["?query", "?foo"]
+  uriFragment <- Gen.element ["#frag", "#bar"]
   return URI {..}
   where
     -- doesn't matter for our needs
     genURIAuth :: m URIAuth
     genURIAuth = pure URIAuth
-      { uriUserInfo = "edna"
+      { uriUserInfo = "edna@"
       , uriRegName = "www.leningrad.spb.ru"
       , uriPort = ":42"
       }

--- a/backend/test/Test/Util/URISpec.hs
+++ b/backend/test/Test/Util/URISpec.hs
@@ -1,0 +1,35 @@
+-- | Tests for @Edna.Util.URI@.
+
+module Test.Util.URISpec
+  ( spec
+  ) where
+
+import Universum
+
+import qualified Data.Aeson as Aeson
+import Hedgehog (forAll, test, tripping)
+import Network.URI (URI, nullURI)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+import Test.Hspec.Hedgehog (hedgehog)
+
+import Edna.Util.URI (parseURI, renderURI)
+
+import Test.Gen (genURI)
+
+spec :: Spec
+spec = do
+  describe "parseURI" $ do
+    it "accepts empty URI" $
+      parseURI "" `shouldBe` Just nullURI
+    it "accepts relative URI" $ do
+      parseURI "foo.bar" `shouldSatisfy` isJust
+      parseURI "foo" `shouldSatisfy` isJust
+    it "is reverse for 'renderURI'" $ hedgehog $ do
+      uri <- forAll genURI
+      test $ tripping uri renderURI parseURI
+  describe "JSON parsing" $ do
+    it "accepts empty URI" $
+      Aeson.decode "\"\"" `shouldBe` Just nullURI
+    it "accepts relative URI" $ do
+      Aeson.decode @URI "\"foo.bar\"" `shouldSatisfy` isJust
+      Aeson.decode @URI "\"foo\"" `shouldSatisfy` isJust


### PR DESCRIPTION
## Description

1. Add `wai-extra`'s middleware and `servant-util`'s `serverWithLogging` to log HTTP requests. The former provides very brief logging, the latter provides verbose logging.
2. Add `logDebug` and `logMessage` functions to log arbitrary messages. Use them somewhere.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-22

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it ← no because logging is quite high-level and it's not important to test it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
