### PR TITLE
[EDNA-55] Define Dashboard API

### DIFF
--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -33,6 +33,8 @@ library
   exposed-modules:
       Edna.Config.Definition
       Edna.Config.Utils
+      Edna.Dashboard.Web.API
+      Edna.Dashboard.Web.Types
       Edna.DB.Connection
       Edna.DB.Initialisation
       Edna.DB.Integration

--- a/backend/src/Edna/Dashboard/Web/API.hs
+++ b/backend/src/Edna/Dashboard/Web/API.hs
@@ -1,0 +1,99 @@
+-- | Dashboard-related part of API definition along with implementation.
+
+module Edna.Dashboard.Web.API
+  ( DashboardEndpoints (..)
+  , DashboardAPI
+  , dashboardEndpoints
+  ) where
+
+import Universum
+
+import Servant (ReqBody)
+import Servant.API (Capture, Delete, Get, JSON, NoContent, Post, Put, QueryParam, Summary, (:>))
+import Servant.API.Generic (AsApi, ToServant, (:-))
+import Servant.Server (err501)
+import Servant.Server.Generic (AsServerT, genericServerT)
+
+import Edna.Dashboard.Web.Types
+import Edna.Setup (Edna)
+import Edna.Util (CompoundId, IdType(..), ProjectId, SubExperimentId, TargetId)
+import Edna.Web.Types (StubSortBy, WithId)
+
+-- TODO: pagination and sorting are just stubs for now.
+
+-- | Endpoints related to projects.
+data DashboardEndpoints route = DashboardEndpoints
+  { -- | Make a sub-experiment default.
+    deMakeDefaultSubExp :: route
+      :- "subExperiment"
+      :> "default"
+      :> Summary "Make a sub-experiment default."
+      :> Capture "subExperimentId" SubExperimentId
+      :> Post '[JSON] (WithId 'SubExperimentId SubExperimentResp)
+
+  , -- | Update the name of a sub-experiment.
+    deSetNameSubExp :: route
+      :- "subExperiment"
+      :> "name"
+      :> Summary "Update the name of a sub-experiment."
+      :> Capture "subExperimentId" SubExperimentId
+      :> ReqBody '[JSON] Text
+      :> Put '[JSON] (WithId 'SubExperimentId SubExperimentResp)
+
+  , -- | Update @isSupicious@ flag of a sub-experiment.
+    deSetIsSuspiciousSubExp :: route
+      :- "subExperiment"
+      :> "suspicious"
+      :> Summary "Update 'isSupicious' flag of a sub-experiment."
+      :> Capture "subExperimentId" SubExperimentId
+      :> ReqBody '[JSON] Bool
+      :> Put '[JSON] (WithId 'SubExperimentId SubExperimentResp)
+
+  , -- | Delete a sub-experiment.
+    deDeleteSubExp :: route
+      :- "subExperiment"
+      :> Summary "Delete a sub-experiment."
+      :> Capture "subExperimentId" SubExperimentId
+      :> Delete '[JSON] NoContent
+
+  , -- | Get known experiments with optional pagination and sorting
+    deGetExperiments :: route
+      :- "experiments"
+      :> Summary "Get known experiments"
+      :> QueryParam "projectId" ProjectId
+      :> QueryParam "compoundId" CompoundId
+      :> QueryParam "targetId" TargetId
+
+      :> QueryParam "page" Word
+      :> QueryParam "size" Word
+      :> QueryParam "sortby" StubSortBy
+      :> Get '[JSON] ExperimentsResp
+
+  , -- | Get sub-experiment's (meta-)data by ID.
+    deGetSubExperiment :: route
+      :- "subExperiment"
+      :> Summary "Get sub-experiment's (meta-)data by ID"
+      :> Capture "subExperimentId" SubExperimentId
+      :> Get '[JSON] (WithId 'SubExperimentId SubExperimentResp)
+
+  , -- | Get sub-experiment's measurements by ID.
+    deGetMeasurements :: route
+      :- "subExperiment"
+      :> Summary "Get sub-experiment's measurements by ID"
+      :> Capture "subExperimentId" SubExperimentId
+      :> "measurements"
+      :> Get '[JSON] [MeasurementResp]
+  } deriving stock (Generic)
+
+type DashboardAPI = ToServant DashboardEndpoints AsApi
+
+dashboardEndpoints :: ToServant DashboardEndpoints (AsServerT Edna)
+dashboardEndpoints = genericServerT DashboardEndpoints
+  { deMakeDefaultSubExp = \_ -> throwM err501
+  , deSetNameSubExp = \_ _ -> throwM err501
+  , deSetIsSuspiciousSubExp = \_ _ -> throwM err501
+  , deDeleteSubExp = \_ -> throwM err501
+  , deGetExperiments = \_ _ _ _ _ _ -> throwM err501
+  , deGetSubExperiment = \_ -> throwM err501
+  , deGetMeasurements = \_ -> throwM err501
+  }

--- a/backend/src/Edna/Dashboard/Web/Types.hs
+++ b/backend/src/Edna/Dashboard/Web/Types.hs
@@ -1,0 +1,116 @@
+-- | Types that exist specifically for Dashboard API.
+
+module Edna.Dashboard.Web.Types
+  ( ExperimentsResp (..)
+  , ExperimentResp (..)
+  , SubExperimentResp (..)
+  , MeasurementResp (..)
+  ) where
+
+import Universum
+
+import Data.Aeson.TH (deriveToJSON)
+import Data.Swagger (ToSchema(..))
+import Data.Time (LocalTime)
+import Data.Time.Format.ISO8601 (iso8601Show)
+import Fmt (Buildable(..), genericF, tupleF, (+|), (|+))
+import Servant.Util.Combinators.Logging (ForResponseLog(..), buildForResponse, buildListForResponse)
+
+import Edna.Util
+  (CompoundId, IdType(..), MethodologyId, ProjectId, SubExperimentId, TargetId, ednaAesonWebOptions,
+  gDeclareNamedSchema, unSqlId)
+import Edna.Web.Types (WithId)
+
+-- | Experiment as response from the server.
+data ExperimentsResp = ExperimentsResp
+  { erExperiments :: [WithId 'ExperimentId ExperimentResp]
+  , erMeanIC50 :: Maybe Double
+  -- ^ If compound and target are selected,
+  -- we also show mean IC50 for this pair.
+  } deriving stock (Generic, Show)
+
+instance Buildable ExperimentsResp where
+  build ExperimentsResp {..} =
+    "Experiments: " +| erExperiments |+ "\nMean IC50: " +| erMeanIC50 |+ ""
+
+instance Buildable (ForResponseLog ExperimentsResp) where
+  build = buildForResponse
+
+-- | Experiment as response from the server.
+data ExperimentResp = ExperimentResp
+  { erProject :: ProjectId
+  -- ^ Project this experiment belongs to.
+  , erCompound :: CompoundId
+  -- ^ Compound involved in this experiment.
+  , erTarget :: TargetId
+  -- ^ Compound involved in this experiment.
+  , erMethodology :: MethodologyId
+  -- ^ Test methodology used in this experiment.
+  , erUploadDate :: LocalTime
+  -- ^ Date when the experiment was uploaded.
+  , erSubExperiments :: [SubExperimentId]
+  -- ^ IDs of all sub-experiments from this experiment.
+  -- Usually their number is small (≤2, maybe 3).
+  } deriving stock (Generic, Show)
+
+instance Buildable ExperimentResp where
+  build ExperimentResp {..} =
+    "Project " +| erProject |+ ", compound " +| erCompound |+ ", target " +| erTarget |+
+    ", methodology " +| erMethodology |+ ", upload date: " +| iso8601Show erUploadDate |+
+    ", sub-experiments: " +| map unSqlId erSubExperiments |+ ""
+
+instance Buildable (ForResponseLog ExperimentResp) where
+  build = buildForResponse
+
+-- | SubExperiment as response from the server.
+data SubExperimentResp = SubExperimentResp
+  { serName :: Text
+  -- ^ Sub-eperiment name.
+  , serIsDefault :: Bool
+  -- ^ Whether this subexperiment is the default one.
+  , serIsSuspicious :: Bool
+  -- ^ Whether this subexperiment's data is suspicious (potentially has
+  -- incorrect points).
+  , serIC50 :: Double
+  -- ^ IC50 computed for this sub-experiment.
+  } deriving stock (Generic, Show)
+
+instance Buildable SubExperimentResp where
+  build = genericF
+
+instance Buildable (ForResponseLog SubExperimentResp) where
+  build = buildForResponse
+
+-- | A single experimental measurement from a sub-experiment.
+data MeasurementResp = MeasurementResp
+  { mrConcentration :: Double
+  -- ^ Concentration for which the signal is measured.
+  , mrSignal :: Double
+  -- ^ Something that is measured.
+  } deriving stock (Generic, Show)
+
+instance Buildable MeasurementResp where
+  build MeasurementResp {..} = tupleF (mrConcentration, mrSignal)
+
+instance Buildable (ForResponseLog MeasurementResp) where
+  build = buildForResponse
+
+instance Buildable (ForResponseLog [MeasurementResp]) where
+  build = buildListForResponse (take 5)
+
+deriveToJSON ednaAesonWebOptions ''ExperimentsResp
+deriveToJSON ednaAesonWebOptions ''ExperimentResp
+deriveToJSON ednaAesonWebOptions ''SubExperimentResp
+deriveToJSON ednaAesonWebOptions ''MeasurementResp
+
+instance ToSchema ExperimentsResp where
+  declareNamedSchema = gDeclareNamedSchema
+
+instance ToSchema ExperimentResp where
+  declareNamedSchema = gDeclareNamedSchema
+
+instance ToSchema SubExperimentResp where
+  declareNamedSchema = gDeclareNamedSchema
+
+instance ToSchema MeasurementResp where
+  declareNamedSchema = gDeclareNamedSchema

--- a/backend/src/Edna/Web/API.hs
+++ b/backend/src/Edna/Web/API.hs
@@ -13,6 +13,7 @@ import Servant.API (GetNoContent, JSON, Post, Summary, (:<|>), (:>))
 import Servant.API.Generic (AsApi, ToServant, (:-))
 import Servant.Multipart (Mem, MultipartData(..), MultipartForm)
 
+import qualified Edna.Dashboard.Web.API as Dashboard
 import qualified Edna.Upload.Web.API as Upload
 
 import Edna.Library.Web.API (CompoundAPI, MethodologyAPI, ProjectAPI, TargetAPI)
@@ -31,6 +32,7 @@ data EdnaEndpoints route = EdnaEndpoints
   , eeMethodologyEndpoints :: route :- MethodologyAPI
   , eeCompoundEndpoints :: route :- CompoundAPI
   , eeTargetEndpoints :: route :- TargetAPI
+  , eeDashboardEndpoints :: route :- Dashboard.DashboardAPI
   } deriving stock (Generic)
 
 -- | API type specification.

--- a/backend/src/Edna/Web/Handlers.hs
+++ b/backend/src/Edna/Web/Handlers.hs
@@ -5,6 +5,7 @@ module Edna.Web.Handlers
 import Servant.API.Generic (ToServant)
 import Servant.Server.Generic (AsServerT, genericServerT)
 
+import qualified Edna.Dashboard.Web.API as Dashboard
 import qualified Edna.Library.Web.API as Library
 import qualified Edna.Upload.Web.API as Upload
 
@@ -22,4 +23,5 @@ ednaHandlers = genericServerT EdnaEndpoints
   , eeMethodologyEndpoints = Library.methodologyEndpoints
   , eeCompoundEndpoints = Library.compoundEndpoints
   , eeTargetEndpoints = Library.targetEndpoints
+  , eeDashboardEndpoints = Dashboard.dashboardEndpoints
   }


### PR DESCRIPTION
## Description

Problem: we are going to implement Dashboard page, but currently there
is no backend API for it.

Solution: define API types and schema. Endpoints will be implemented
later, currently we use stubs with 501 HTTP code.

Note: currently we don't define any endpoints necessary to drop points
and create new sub-experiments. They will be added later.

![image](https://user-images.githubusercontent.com/2556409/112817670-5ec8bd80-908b-11eb-91ab-7d83e077505c.png)




<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-55

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

We don't have API tests for now.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
