### PR TITLE
Use UTCTime on API types

### DIFF
--- a/backend/src/Edna/Dashboard/Web/Types.hs
+++ b/backend/src/Edna/Dashboard/Web/Types.hs
@@ -11,7 +11,7 @@ import Universum
 
 import Data.Aeson.TH (deriveToJSON)
 import Data.Swagger (ToSchema(..))
-import Data.Time (LocalTime)
+import Data.Time (UTCTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
 import Fmt (Buildable(..), genericF, tupleF, (+|), (|+))
 import Servant.Util.Combinators.Logging (ForResponseLog(..), buildForResponse, buildListForResponse)
@@ -46,7 +46,7 @@ data ExperimentResp = ExperimentResp
   -- ^ Compound involved in this experiment.
   , erMethodology :: MethodologyId
   -- ^ Test methodology used in this experiment.
-  , erUploadDate :: LocalTime
+  , erUploadDate :: UTCTime
   -- ^ Date when the experiment was uploaded.
   , erSubExperiments :: [SubExperimentId]
   -- ^ IDs of all sub-experiments from this experiment.

--- a/backend/src/Edna/Library/DB/Query.hs
+++ b/backend/src/Edna/Library/DB/Query.hs
@@ -45,7 +45,7 @@ import Edna.Library.Web.Types
 import Edna.Setup (Edna)
 import Edna.Upload.DB.Schema (ExperimentFileT(..))
 import Edna.Util as U
-  (CompoundId, IdType(..), MethodologyId, ProjectId, SqlId(..), TargetId, justOrError)
+  (CompoundId, IdType(..), MethodologyId, ProjectId, SqlId(..), TargetId, justOrError, localToUTC)
 import Edna.Util.URI (renderURI)
 import Edna.Web.Types (WithId(..))
 
@@ -57,7 +57,7 @@ targetToDomain :: TargetId -> TargetRec -> [Maybe ProjectRec] -> WithId 'U.Targe
 targetToDomain targetSqlId TargetRec{..} projects = WithId targetSqlId $ TargetResp
   { trName = tName
   , trProjects = mapMaybe (fmap pName) projects
-  , trAdditionDate = tAdditionDate
+  , trAdditionDate = localToUTC tAdditionDate
   }
 
 -- TODO maybe we should move it to Service layer
@@ -221,8 +221,8 @@ projectToDomain
 projectToDomain projectSqlId ProjectRec{..} compounds = WithId projectSqlId $ ProjectResp
   { prName = pName
   , prDescription = pDescription
-  , prCreationDate = pCreationDate
-  , prLastUpdate = pLastUpdate
+  , prCreationDate = localToUTC pCreationDate
+  , prLastUpdate = localToUTC pLastUpdate
   , prCompoundNames = mapMaybe (fmap cName) compounds
   }
 

--- a/backend/src/Edna/Library/Service.hs
+++ b/backend/src/Edna/Library/Service.hs
@@ -32,7 +32,7 @@ import Edna.Library.Web.Types
   (CompoundResp(..), MethodologyReqResp(..), ProjectReq(..), ProjectResp, TargetResp)
 import Edna.Logging (logMessage)
 import Edna.Setup (Edna)
-import Edna.Util (IdType(..), SqlId(..), ensureOrThrow, justOrThrow, nothingOrThrow)
+import Edna.Util (IdType(..), SqlId(..), ensureOrThrow, justOrThrow, localToUTC, nothingOrThrow)
 import Edna.Util.URI (parseURI, renderURI)
 import Edna.Web.Types (StubSortBy, URI, WithId(..))
 
@@ -54,7 +54,7 @@ compoundToResp CompoundRec{..} = do
   pure $ WithId (SqlId $ unSerial cCompoundId) $ CompoundResp
     { crName = cName
     , crChemSoft = url
-    , crAdditionDate = cAdditionDate
+    , crAdditionDate = localToUTC cAdditionDate
     }
 
 getCompound :: SqlId 'CompoundId -> Edna (WithId 'CompoundId CompoundResp)

--- a/backend/src/Edna/Library/Web/Types.hs
+++ b/backend/src/Edna/Library/Web/Types.hs
@@ -12,7 +12,7 @@ import Universum
 
 import Data.Aeson.TH (deriveJSON)
 import Data.Swagger (ToSchema(..))
-import Data.Time (LocalTime)
+import Data.Time (UTCTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
 import Fmt (Buildable(..), genericF, (+|), (|+))
 import Network.URI.JSON ()
@@ -40,8 +40,8 @@ instance Buildable (ForResponseLog ProjectReq) where
 data ProjectResp = ProjectResp
   { prName :: Text
   , prDescription :: Maybe Text
-  , prCreationDate :: LocalTime
-  , prLastUpdate :: LocalTime
+  , prCreationDate :: UTCTime
+  , prLastUpdate :: UTCTime
   , prCompoundNames :: [Text]
   -- ^ Names of all compounds involved in this project.
   } deriving stock (Generic, Show)
@@ -87,7 +87,7 @@ data TargetResp = TargetResp
   -- ^ Name of the target.
   , trProjects :: [Text]
   -- ^ Names of all projects where this target is involved.
-  , trAdditionDate :: LocalTime
+  , trAdditionDate :: UTCTime
   -- ^ Timestamp when this target was added to the system (by uploading a file).
   } deriving stock (Generic, Show)
 
@@ -112,7 +112,7 @@ data CompoundResp = CompoundResp
   -- ^ Name of the compound, it may be changed to be a number later.
   , crChemSoft :: Maybe URI
   -- ^ Link to ChemSoft.
-  , crAdditionDate :: LocalTime
+  , crAdditionDate :: UTCTime
   -- ^ Timestamp when this compound was added to the system (by uploading a file).
   } deriving stock (Generic, Show)
 

--- a/backend/src/Edna/Util.hs
+++ b/backend/src/Edna/Util.hs
@@ -23,6 +23,7 @@ module Edna.Util
   , justOrError
   , fromSqlSerial
   , rightOrThrow
+  , localToUTC
   ) where
 
 import Universum
@@ -38,6 +39,7 @@ import Data.Swagger.Internal.ParamSchema (GToParamSchema, genericToParamSchema)
 import qualified Data.Swagger.Internal.Schema as S
 import Data.Swagger.Internal.TypeShape (GenericHasSimpleShape, GenericShape)
 import Data.Swagger.SchemaOptions (SchemaOptions, fromAesonOptions)
+import Data.Time (LocalTime, UTCTime, localTimeToUTC, utc)
 import Database.Beam.Backend (SqlSerial(..))
 import Fmt (Buildable(..), pretty, (+|), (|+))
 import qualified GHC.Generics as G
@@ -166,6 +168,9 @@ ensureOrThrow e b
 
 rightOrThrow :: (MonadThrow m, Exception e) => (b -> e) -> Either b a -> m a
 rightOrThrow f = either (throwM . f) pure
+
+localToUTC :: LocalTime -> UTCTime
+localToUTC = localTimeToUTC utc
 
 ----------------
 -- SqlId


### PR DESCRIPTION
Problem: currently we use LocalTime for API types but in doesn't have
timezone and on frontend it is needed to manage user timezone

Solution: use UTCTime in API types and convert DB LocalTime to UTCTime

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-60

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
