### PR TITLE
[EDNA-73] Extend Dashboard API

### DIFF
--- a/backend/src/Edna/Analysis/FourPL.hs
+++ b/backend/src/Edna/Analysis/FourPL.hs
@@ -53,4 +53,4 @@ instance ToSchema Params4PL where
 --
 -- TODO [EDNA-71] Implement!
 analyse4PL :: [(Double, Double)] -> IO Params4PL
-analyse4PL _ = pure (Params4PL 1 2 3 4)
+analyse4PL _ = pure (Params4PL 36404 1.14 33 -2552)

--- a/backend/src/Edna/Analysis/FourPL.hs
+++ b/backend/src/Edna/Analysis/FourPL.hs
@@ -10,6 +10,7 @@ import Universum
 import Data.Aeson (FromJSON(..), ToJSON(..))
 import Data.Swagger (ToSchema(..))
 import Fmt (Buildable(..), tupleF)
+import Servant.Util.Combinators.Logging (ForResponseLog, buildForResponse)
 
 -- | Parameters of 4PL function, analysis outcome of this analysis method.
 -- The function is defined as follows:
@@ -30,6 +31,9 @@ toTuple Params4PL {..} = (p4plA, p4plB, p4plC, p4plD)
 
 instance Buildable Params4PL where
   build = tupleF . toTuple
+
+instance Buildable (ForResponseLog Params4PL) where
+  build = buildForResponse
 
 -- Serializing as a tuple for brevity.
 instance ToJSON Params4PL where

--- a/backend/src/Edna/Dashboard/DB/Query.hs
+++ b/backend/src/Edna/Dashboard/DB/Query.hs
@@ -72,8 +72,8 @@ setIsSuspiciousSubExperiment (SqlId subExpId) isSuspicious =
 -- entries for this sub-experiment.
 --
 -- Does not delete primary sub-experiments.
--- Returns @True@ iff sub-experiment was successfully deleted (i. e. is not
--- primary).
+-- Returns @True@ iff sub-experiment was successfully deleted (i. e. is known and
+-- not primary).
 deleteSubExperiment :: SubExperimentId -> Edna Bool
 deleteSubExperiment (SqlId subExpId) =
   fmap (not . null) $ runDeleteReturningList' $

--- a/backend/src/Edna/Dashboard/DB/Query.hs
+++ b/backend/src/Edna/Dashboard/DB/Query.hs
@@ -5,10 +5,12 @@ module Edna.Dashboard.DB.Query
   , setNameSubExperiment
   , setIsSuspiciousSubExperiment
   , deleteSubExperiment
+  , createSubExperiment
   , getExperiments
   , getSubExperiment
   , getMeasurements
   , getRemovedMeasurements
+  , getExperimentId
   ) where
 
 import Universum
@@ -17,13 +19,17 @@ import qualified Data.List.NonEmpty as NE
 
 import Data.Time (LocalTime)
 import Database.Beam.Backend (SqlSerial(..))
+import Database.Beam.Postgres (PgJSON(..), Postgres)
 import Database.Beam.Postgres.Full (deleteReturning)
 import Database.Beam.Query
-  (aggregate_, all_, as_, asc_, cast_, countAll_, guard_, int, leftJoin_, lookup_, orderBy_, select,
-  subquery_, update, val_, (&&.), (<-.), (==.))
+  (QExpr, aggregate_, all_, as_, asc_, cast_, countAll_, default_, guard_, insert,
+  insertExpressions, int, leftJoin_, lookup_, orderBy_, select, subquery_, update, val_, (&&.),
+  (<-.), (==.))
 
+import Edna.Analysis.FourPL (Params4PL)
 import Edna.DB.Integration
-  (runDeleteReturningList', runSelectReturningList', runSelectReturningOne', runUpdate')
+  (runDeleteReturningList', runInsertReturningOne', runSelectReturningList', runSelectReturningOne',
+  runUpdate')
 import Edna.DB.Schema (EdnaSchema(..), ednaSchema)
 import Edna.Dashboard.DB.Schema
 import Edna.Dashboard.Web.Types (ExperimentResp(..))
@@ -76,6 +82,23 @@ deleteSubExperiment (SqlId subExpId) =
        pure primarySubExp)
      )
   ) seSubExperimentId
+
+-- | Create a new sub-experiment as a sibling of existing one (sharing
+-- given experiment ID).
+createSubExperiment :: ExperimentId -> Text -> Params4PL -> Edna SubExperimentRec
+createSubExperiment (SqlId experimentId) newName result =
+  runInsertReturningOne'
+    (insert (esSubExperiment ednaSchema) $ insertExpressions [newSubExpRec])
+  where
+    newSubExpRec :: SubExperimentT (QExpr Postgres s)
+    newSubExpRec = SubExperimentRec
+      { seSubExperimentId = default_
+      , seAnalysisMethodId = val_ theOnlyAnalysisMethodId
+      , seName = val_ newName
+      , seExperimentId = val_ experimentId
+      , seIsSuspicious = val_ False
+      , seResult = val_ (PgJSON result)
+      }
 
 -- | Get data about all experiments using 3 optional filters: by project ID,
 -- compound ID and target ID.
@@ -141,13 +164,11 @@ getSubExperiment (SqlId subExperimentId) = runSelectReturningOne' $
 
 -- | Get all measurements from the given sub-experiment:
 -- both active and inactive (removed).
-getMeasurements :: SubExperimentId -> Edna [MeasurementRec]
-getMeasurements i = getSubExperiment i >>= \case
-  Nothing -> pure []
-  Just se -> runSelectReturningList' $ select $ do
-    measurement <- all_ $ esMeasurement ednaSchema
-    guard_ (mExperimentId measurement ==. val_ (seExperimentId se))
-    pure measurement
+getMeasurements :: ExperimentId -> Edna [MeasurementRec]
+getMeasurements (SqlId experimentId) = runSelectReturningList' $ select $ do
+  measurement <- all_ $ esMeasurement ednaSchema
+  guard_ (mExperimentId measurement ==. val_ experimentId)
+  pure measurement
 
 -- | Get IDs of all measurements deactivated in the sub-experiment with given ID.
 getRemovedMeasurements :: SubExperimentId -> Edna [MeasurementId]
@@ -156,3 +177,11 @@ getRemovedMeasurements (SqlId subExperimentId) =
     removedMeasurement <- all_ $ esRemovedMeasurements ednaSchema
     guard_ (rmSubExperimentId removedMeasurement ==. val_ subExperimentId)
     pure removedMeasurement
+
+-- | Get ID of experiment that stores sub-experiment with given ID.
+getExperimentId :: SubExperimentId -> Edna (Maybe ExperimentId)
+getExperimentId (SqlId subExpId) =
+  (SqlId <<$>>) . runSelectReturningOne' $ select $ do
+    subExperiment <- all_ $ esSubExperiment ednaSchema
+    guard_ (seSubExperimentId subExperiment ==. val_ (SqlSerial subExpId))
+    pure (seExperimentId subExperiment)

--- a/backend/src/Edna/Dashboard/Error.hs
+++ b/backend/src/Edna/Dashboard/Error.hs
@@ -9,17 +9,19 @@ import Universum
 import Fmt (Buildable(..), pretty)
 import Servant (ServerError(..), err400, err404)
 
-import Edna.Util (SubExperimentId)
+import Edna.Util (ExperimentId, SubExperimentId)
 import Edna.Web.Error (ToServerError(..))
 
 data DashboardError
   = DESubExperimentNotFound SubExperimentId
+  | DEExperimentNotFound ExperimentId
   | DECantDeletePrimary SubExperimentId
   deriving stock (Show, Eq)
 
 instance Buildable DashboardError where
   build = \case
     DESubExperimentNotFound i -> "Sub-experiment not found: " <> build i
+    DEExperimentNotFound i -> "Experiment not found: " <> build i
     DECantDeletePrimary i ->
       "It's not allowed to delete primary sub-experiments (" <> build i <>
       "), please choose the new primary one first"
@@ -30,6 +32,7 @@ instance Exception DashboardError where
 instance ToServerError DashboardError where
   toServerError err = case err of
     DESubExperimentNotFound _ -> err404 { errBody = prettyErr }
+    DEExperimentNotFound _ -> err404 { errBody = prettyErr }
     DECantDeletePrimary _ -> err400 { errBody = prettyErr }
     where
       prettyErr = encodeUtf8 @Text $ pretty err

--- a/backend/src/Edna/Dashboard/Service.hs
+++ b/backend/src/Edna/Dashboard/Service.hs
@@ -10,6 +10,7 @@ module Edna.Dashboard.Service
   , analyseNewSubExperiment
   , getExperiments
   , getExperimentMetadata
+  , getExperimentFile
   , getSubExperiment
   , getMeasurements
   ) where
@@ -30,8 +31,8 @@ import Edna.DB.Integration (transact)
 import Edna.Dashboard.DB.Schema (MeasurementT(..), SubExperimentRec, SubExperimentT(..))
 import Edna.Dashboard.Error (DashboardError(..))
 import Edna.Dashboard.Web.Types
-  (ExperimentMetadata(..), ExperimentResp(..), ExperimentsResp(..), MeasurementResp(..),
-  NewSubExperimentReq(..), SubExperimentResp(..))
+  (ExperimentFileBlob(..), ExperimentMetadata(..), ExperimentResp(..), ExperimentsResp(..),
+  MeasurementResp(..), NewSubExperimentReq(..), SubExperimentResp(..))
 import Edna.ExperimentReader.Types (FileMetadata(..))
 import Edna.Logging (logMessage)
 import Edna.Setup (Edna)
@@ -161,6 +162,14 @@ getExperimentMetadata expId =
   Q.getDescriptionAndMetadata expId >>=
   justOrThrow (DEExperimentNotFound expId) <&>
   \(description, PgJSON (FileMetadata meta)) -> ExperimentMetadata description meta
+
+-- | Get contents of experiment file that stores experiment with given ID.
+-- File name is also returned.
+getExperimentFile :: ExperimentId -> Edna (Text, ExperimentFileBlob)
+getExperimentFile expId =
+  Q.getFileNameAndBlob expId >>=
+  justOrThrow (DEExperimentNotFound expId) <&>
+  second ExperimentFileBlob
 
 -- | Get sub-experiment with given ID.
 getSubExperiment :: SubExperimentId -> Edna (WithId 'SubExperimentId SubExperimentResp)

--- a/backend/src/Edna/Dashboard/Service.hs
+++ b/backend/src/Edna/Dashboard/Service.hs
@@ -25,6 +25,7 @@ import Fmt (fmt, (+|), (|+))
 import Servant.API (NoContent(..))
 
 import qualified Edna.Dashboard.DB.Query as Q
+import qualified Edna.Upload.DB.Query as UQ
 
 import Edna.Analysis.FourPL (Params4PL(..), analyse4PL)
 import Edna.DB.Integration (transact)
@@ -90,7 +91,7 @@ newSubExperiment subExpId req = do
     expId <-
       justOrThrow (DESubExperimentNotFound subExpId) =<< Q.getExperimentId subExpId
     result <- subExperimentRecToResp <$>
-      Q.createSubExperiment expId (nserName req) newResult
+      UQ.insertSubExperiment expId (nserName req) newResult
     result <$ insertRemovedMeasurements (wiId result) removed
 
 -- | A version of 'newSubExperiment' that doesn't save anything to the DB.

--- a/backend/src/Edna/Dashboard/Web/API.hs
+++ b/backend/src/Edna/Dashboard/Web/API.hs
@@ -15,11 +15,12 @@ import Servant.Server.Generic (AsServerT, genericServerT)
 
 import Edna.Analysis.FourPL (Params4PL)
 import Edna.Dashboard.Service
-  (analyseNewSubExperiment, deleteSubExperiment, getExperiments, getMeasurements, getSubExperiment,
-  makePrimarySubExperiment, newSubExperiment, setIsSuspiciousSubExperiment, setNameSubExperiment)
+  (analyseNewSubExperiment, deleteSubExperiment, getExperimentMetadata, getExperiments,
+  getMeasurements, getSubExperiment, makePrimarySubExperiment, newSubExperiment,
+  setIsSuspiciousSubExperiment, setNameSubExperiment)
 import Edna.Dashboard.Web.Types
 import Edna.Setup (Edna)
-import Edna.Util (CompoundId, IdType(..), ProjectId, SubExperimentId, TargetId)
+import Edna.Util (CompoundId, ExperimentId, IdType(..), ProjectId, SubExperimentId, TargetId)
 import Edna.Web.Types (StubSortBy, WithId)
 
 -- TODO: pagination and sorting are just stubs for now.
@@ -91,6 +92,14 @@ data DashboardEndpoints route = DashboardEndpoints
       :> QueryParam "sortby" StubSortBy
       :> Get '[JSON] ExperimentsResp
 
+  , -- | Get experiment's metadata by ID
+    deGetExperimentMetadata :: route
+      :- "experiment"
+      :> Summary "Get experiment's metadata by ID"
+      :> Capture "experimentId" ExperimentId
+      :> "metadata"
+      :> Get '[JSON] ExperimentMetadata
+
   , -- | Get sub-experiment's (meta-)data by ID.
     deGetSubExperiment :: route
       :- "subExperiment"
@@ -118,6 +127,7 @@ dashboardEndpoints = genericServerT DashboardEndpoints
   , deNewSubExp = newSubExperiment
   , deAnalyseNewSubExp = fmap snd ... analyseNewSubExperiment
   , deGetExperiments = \p c t _ _ _ -> getExperiments p c t
+  , deGetExperimentMetadata = getExperimentMetadata
   , deGetSubExperiment = getSubExperiment
   , deGetMeasurements = getMeasurements
   }

--- a/backend/src/Edna/Dashboard/Web/API.hs
+++ b/backend/src/Edna/Dashboard/Web/API.hs
@@ -15,7 +15,7 @@ import Servant.Server.Generic (AsServerT, genericServerT)
 
 import Edna.Dashboard.Service
   (deleteSubExperiment, getExperiments, getMeasurements, getSubExperiment, makePrimarySubExperiment,
-  setIsSuspiciousSubExperiment, setNameSubExperiment)
+  newSubExperiment, setIsSuspiciousSubExperiment, setNameSubExperiment)
 import Edna.Dashboard.Web.Types
 import Edna.Setup (Edna)
 import Edna.Util (CompoundId, IdType(..), ProjectId, SubExperimentId, TargetId)
@@ -58,6 +58,15 @@ data DashboardEndpoints route = DashboardEndpoints
       :> Capture "subExperimentId" SubExperimentId
       :> Delete '[JSON] NoContent
 
+  , -- | Create a new sub-experiment from existing one.
+    deNewSubExp :: route
+      :- "subExperiment"
+      :> Summary "Create a new sub-experiment from existing one."
+      :> Capture "subExperimentId" SubExperimentId
+      :> "new"
+      :> ReqBody '[JSON] NewSubExperimentReq
+      :> Post '[JSON] (WithId 'SubExperimentId SubExperimentResp)
+
   , -- | Get known experiments with optional pagination and sorting
     deGetExperiments :: route
       :- "experiments"
@@ -84,7 +93,7 @@ data DashboardEndpoints route = DashboardEndpoints
       :> Summary "Get sub-experiment's measurements by ID"
       :> Capture "subExperimentId" SubExperimentId
       :> "measurements"
-      :> Get '[JSON] [MeasurementResp]
+      :> Get '[JSON] [WithId 'MeasurementId MeasurementResp]
   } deriving stock (Generic)
 
 type DashboardAPI = ToServant DashboardEndpoints AsApi
@@ -95,6 +104,7 @@ dashboardEndpoints = genericServerT DashboardEndpoints
   , deSetNameSubExp = setNameSubExperiment
   , deSetIsSuspiciousSubExp = setIsSuspiciousSubExperiment
   , deDeleteSubExp = deleteSubExperiment
+  , deNewSubExp = newSubExperiment
   , deGetExperiments = \p c t _ _ _ -> getExperiments p c t
   , deGetSubExperiment = getSubExperiment
   , deGetMeasurements = getMeasurements

--- a/backend/src/Edna/Dashboard/Web/API.hs
+++ b/backend/src/Edna/Dashboard/Web/API.hs
@@ -13,9 +13,10 @@ import Servant.API (Capture, Delete, Get, JSON, NoContent, Post, Put, QueryParam
 import Servant.API.Generic (AsApi, ToServant, (:-))
 import Servant.Server.Generic (AsServerT, genericServerT)
 
+import Edna.Analysis.FourPL (Params4PL)
 import Edna.Dashboard.Service
-  (deleteSubExperiment, getExperiments, getMeasurements, getSubExperiment, makePrimarySubExperiment,
-  newSubExperiment, setIsSuspiciousSubExperiment, setNameSubExperiment)
+  (analyseNewSubExperiment, deleteSubExperiment, getExperiments, getMeasurements, getSubExperiment,
+  makePrimarySubExperiment, newSubExperiment, setIsSuspiciousSubExperiment, setNameSubExperiment)
 import Edna.Dashboard.Web.Types
 import Edna.Setup (Edna)
 import Edna.Util (CompoundId, IdType(..), ProjectId, SubExperimentId, TargetId)
@@ -67,6 +68,16 @@ data DashboardEndpoints route = DashboardEndpoints
       :> ReqBody '[JSON] NewSubExperimentReq
       :> Post '[JSON] (WithId 'SubExperimentId SubExperimentResp)
 
+  , -- | Analyse a new sub-experiment that is not created yet.
+    deAnalyseNewSubExp :: route
+      :- "subExperiment"
+      :> Summary "Analyse a new sub-experiment that is not created yet."
+      :> Capture "subExperimentId" SubExperimentId
+      :> "new"
+      :> "analyse"
+      :> ReqBody '[JSON] NewSubExperimentReq
+      :> Post '[JSON] Params4PL
+
   , -- | Get known experiments with optional pagination and sorting
     deGetExperiments :: route
       :- "experiments"
@@ -105,6 +116,7 @@ dashboardEndpoints = genericServerT DashboardEndpoints
   , deSetIsSuspiciousSubExp = setIsSuspiciousSubExperiment
   , deDeleteSubExp = deleteSubExperiment
   , deNewSubExp = newSubExperiment
+  , deAnalyseNewSubExp = fmap snd ... analyseNewSubExperiment
   , deGetExperiments = \p c t _ _ _ -> getExperiments p c t
   , deGetSubExperiment = getSubExperiment
   , deGetMeasurements = getMeasurements

--- a/backend/src/Edna/Dashboard/Web/Types.hs
+++ b/backend/src/Edna/Dashboard/Web/Types.hs
@@ -6,6 +6,7 @@ module Edna.Dashboard.Web.Types
   , ExperimentResp (..)
   , SubExperimentResp (..)
   , MeasurementResp (..)
+  , ExperimentMetadata (..)
   ) where
 
 import Universum
@@ -120,11 +121,26 @@ instance Buildable (ForResponseLog MeasurementResp) where
 instance Buildable (ForResponseLog [MeasurementResp]) where
   build = buildListForResponse (take 5)
 
+-- | All metadata about an experiment.
+data ExperimentMetadata = ExperimentMetadata
+  { emDescription :: Text
+  -- ^ Description provided manually during file upload.
+  , emFileMetadata :: [Text]
+  -- ^ Metadata stored inside the corresponding file.
+  } deriving stock (Generic, Show, Eq)
+
+instance Buildable ExperimentMetadata where
+  build = genericF
+
+instance Buildable (ForResponseLog ExperimentMetadata) where
+  build = buildForResponse
+
 deriveJSON ednaAesonWebOptions ''NewSubExperimentReq
 deriveToJSON ednaAesonWebOptions ''ExperimentsResp
 deriveToJSON ednaAesonWebOptions ''ExperimentResp
 deriveToJSON ednaAesonWebOptions ''SubExperimentResp
 deriveToJSON ednaAesonWebOptions ''MeasurementResp
+deriveToJSON ednaAesonWebOptions ''ExperimentMetadata
 
 instance ToSchema NewSubExperimentReq where
   declareNamedSchema = gDeclareNamedSchema
@@ -139,4 +155,7 @@ instance ToSchema SubExperimentResp where
   declareNamedSchema = gDeclareNamedSchema
 
 instance ToSchema MeasurementResp where
+  declareNamedSchema = gDeclareNamedSchema
+
+instance ToSchema ExperimentMetadata where
   declareNamedSchema = gDeclareNamedSchema

--- a/backend/src/Edna/Util.hs
+++ b/backend/src/Edna/Util.hs
@@ -44,6 +44,7 @@ import Database.Beam.Backend (SqlSerial(..))
 import Fmt (Buildable(..), pretty, (+|), (|+))
 import qualified GHC.Generics as G
 import Servant (FromHttpApiData(..))
+import Servant.Util.Combinators.Logging (ForResponseLog, buildForResponse)
 import qualified Text.ParserCombinators.ReadP as ReadP
 import Text.Read (Read(..), read)
 import qualified Text.Show
@@ -188,6 +189,9 @@ newtype SqlId (t :: IdType) = SqlId
 
 instance Buildable (SqlId t) where
   build (SqlId n) = "ID#" <> build n
+
+instance Buildable (ForResponseLog (SqlId t)) where
+  build = buildForResponse
 
 instance ToParamSchema (SqlId t) where
   toParamSchema = gToParamSchema

--- a/backend/test/Test/DashboardSpec.hs
+++ b/backend/test/Test/DashboardSpec.hs
@@ -83,7 +83,7 @@ spec = withContext $ do
             , measurements4
             , measurements5
             , measurements6
-            ] <- mapM getMeasurements validSubExperimentIds
+            ] <- mapM ((wItem <<$>>) . getMeasurements) validSubExperimentIds
           let
             toMeasurementResp :: Measurement -> MeasurementResp
             toMeasurementResp Measurement {..} = MeasurementResp
@@ -99,9 +99,9 @@ spec = withContext $ do
             measurements4 `shouldBe` map toMeasurementResp [m1, m2, m5]
             measurements5 `shouldBe` map toMeasurementResp [m1, m5]
             measurements6 `shouldBe` map toMeasurementResp [m3, m4, m5]
-        it "returns empty list for unknown sub-experiment" $ runTestEdna $ do
-          measurements <- getMeasurements unknownSubExpId
-          liftIO $ measurements `shouldBe` []
+        it "fails for unknown sub-experiment" $ \ctx -> do
+          runRIO ctx (getMeasurements unknownSubExpId) `shouldThrow`
+            (== DESubExperimentNotFound unknownSubExpId)
     describe "setNameSubExperiment" $ do
       it "updates the name of a sub-experiment to the given one" $ runTestEdna do
         resp <- setNameSubExperiment sampleSubExpId "newName"

--- a/backend/test/Test/DashboardSpec.hs
+++ b/backend/test/Test/DashboardSpec.hs
@@ -158,7 +158,7 @@ gettersSpec = do
           getExperiments (Just $ SqlId 1) (Just compoundId) (Just targetId)
         liftIO $ do
           length erExperiments `shouldBe` 1
-          erMeanIC50 `shouldBe` Just 3
+          erMeanIC50 `shouldBe` Just 33
           forM_ erExperiments $ \(WithId _ ExperimentResp {..}) ->
             erTarget `shouldBe` targetId
     describe "getExperimentMetadata" $ do

--- a/backend/test/Test/DashboardSpec.hs
+++ b/backend/test/Test/DashboardSpec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
 -- | Tests for the Dashboard service.
 
 module Test.DashboardSpec
@@ -7,101 +9,43 @@ module Test.DashboardSpec
 import Universum
 
 import RIO (runRIO)
-import Test.Hspec (Spec, beforeAllWith, describe, it, shouldBe, shouldSatisfy, shouldThrow)
+import Test.Hspec
+  (Spec, SpecWith, beforeAllWith, describe, it, shouldBe, shouldSatisfy, shouldThrow)
 
+import Edna.Analysis.FourPL (analyse4PL)
 import Edna.Dashboard.Error (DashboardError(..))
 import Edna.Dashboard.Service
-  (deleteSubExperiment, getExperiments, getMeasurements, getSubExperiment,
+  (analyseNewSubExperiment, deleteSubExperiment, getExperimentFile, getExperimentMetadata,
+  getExperiments, getMeasurements, getSubExperiment, makePrimarySubExperiment, newSubExperiment,
   setIsSuspiciousSubExperiment, setNameSubExperiment)
 import Edna.Dashboard.Web.Types
-  (ExperimentResp(..), ExperimentsResp(..), MeasurementResp(..), SubExperimentResp(..))
-import Edna.ExperimentReader.Types (Measurement(..))
-import Edna.Util (SqlId(..), SubExperimentId)
+  (ExperimentFileBlob(..), ExperimentMetadata(..), ExperimentResp(..), ExperimentsResp(..),
+  MeasurementResp(..), NewSubExperimentReq(..), SubExperimentResp(..))
+import Edna.ExperimentReader.Types (FileMetadata(unFileMetadata), Measurement(..))
+import Edna.Setup (EdnaContext)
+import Edna.Util (ExperimentId, IdType(..), SqlId(..), SubExperimentId)
 import Edna.Web.Types (WithId(..))
 
 import Test.Orphans ()
 import Test.SampleData
 import Test.Setup (runTestEdna, runWithInit, withContext)
 
--- TODO [EDNA-73] Add the following tests:
--- 1. makePrimarySubExperiment
--- 2. Successful deleteSubExperiment
--- 3. Addition of sub-experiments (functionality will be implemented in EDNA-73)
 spec :: Spec
 spec = withContext $ do
   beforeAllWith (\ctx -> ctx <$ runWithInit ctx addSampleData) $ do
-    describe "getters" $ do
-      describe "getExperiments" $ do
-        it "returns all experiments and no IC50 with no filters" $ runTestEdna $ do
-          ExperimentsResp {..} <- getExperiments Nothing Nothing Nothing
-          liftIO $ do
-            length erExperiments `shouldBe` 12
-            erMeanIC50 `shouldBe` Nothing
-        it "filters by project correctly" $ runTestEdna $ do
-          ExperimentsResp {..} <- getExperiments (Just $ SqlId 1) Nothing Nothing
-          liftIO $ do
-            length erExperiments `shouldBe` 6
-            erMeanIC50 `shouldBe` Nothing
-            forM_ erExperiments $ \(WithId _ ExperimentResp {..}) ->
-              erProject `shouldBe` SqlId 1
-        it "filters by project and compound correctly" $ runTestEdna $ do
-          let compoundId = SqlId 2
-          ExperimentsResp {..} <-
-            getExperiments (Just $ SqlId 1) (Just compoundId) Nothing
-          liftIO $ do
-            length erExperiments `shouldBe` 2
-            erMeanIC50 `shouldBe` Nothing
-            forM_ erExperiments $ \(WithId _ ExperimentResp {..}) ->
-              erCompound `shouldBe` compoundId
-        it "filters by 3 filters correctly and returns mean IC50" $ runTestEdna $ do
-          let compoundId = SqlId 2
-          let targetId = SqlId 2
-          ExperimentsResp {..} <-
-            getExperiments (Just $ SqlId 1) (Just compoundId) (Just targetId)
-          liftIO $ do
-            length erExperiments `shouldBe` 1
-            erMeanIC50 `shouldBe` Just 3
-            forM_ erExperiments $ \(WithId _ ExperimentResp {..}) ->
-              erTarget `shouldBe` targetId
-      describe "getSubExperiment" $ do
-        it "returns correct results for sub-experiments 1-6" $ runTestEdna $ do
-          resps <- forM validSubExperimentIds $ \subExpId -> do
-            WithId gotId gotResp <- getSubExperiment subExpId
-            liftIO $ gotId `shouldBe` subExpId
-            return gotResp
-          -- Very simple check
-          liftIO $ forM_ resps $ \resp ->
-            resp `shouldSatisfy` ((False == ) . serIsSuspicious)
-        it "fails for unknown sub-experiment" $ \ctx -> do
-          runRIO ctx (getSubExperiment unknownSubExpId) `shouldThrow`
-            (== DESubExperimentNotFound unknownSubExpId)
-      describe "getMeasurements" $ do
-        it "returns correct measurements for sub-experiments 1-6" $ runTestEdna $ do
-          [ measurements1
-            , measurements2
-            , measurements3
-            , measurements4
-            , measurements5
-            , measurements6
-            ] <- mapM ((wItem <<$>>) . getMeasurements) validSubExperimentIds
-          let
-            toMeasurementResp :: Measurement -> MeasurementResp
-            toMeasurementResp Measurement {..} = MeasurementResp
-              { mrConcentration = mConcentration
-              , mrSignal = mSignal
-              , mrIsEnabled = not mIsOutlier
-              }
-          -- These lists match lists in @targetMeasurementsX@ values from SampleData.
-          liftIO $ do
-            measurements1 `shouldBe` map toMeasurementResp [m1, m2, m3]
-            measurements2 `shouldBe` map toMeasurementResp [m2, m4, m5]
-            measurements3 `shouldBe` map toMeasurementResp [m1, m3, m4]
-            measurements4 `shouldBe` map toMeasurementResp [m1, m2, m5]
-            measurements5 `shouldBe` map toMeasurementResp [m1, m5]
-            measurements6 `shouldBe` map toMeasurementResp [m3, m4, m5]
-        it "fails for unknown sub-experiment" $ \ctx -> do
-          runRIO ctx (getMeasurements unknownSubExpId) `shouldThrow`
-            (== DESubExperimentNotFound unknownSubExpId)
+    gettersSpec
+    describe "makePrimarySubExperiment" $ do
+      it "makes given sub-experiment the primary one for its parent" $ runTestEdna do
+        resp <- makePrimarySubExperiment secondarySubExpId
+        getResp <- getSubExperiment secondarySubExpId
+        ExperimentsResp {..} <- getExperiments
+          (Just $ SqlId 1) Nothing Nothing
+        let WithId _ ExperimentResp {..}: _ =
+              filter (\withId -> wiId withId == SqlId 1) erExperiments
+        liftIO $ do
+          resp `shouldBe` getResp
+          erPrimarySubExperiment `shouldBe` secondarySubExpId
+        void $ makePrimarySubExperiment sampleSubExpId -- undo changes
     describe "setNameSubExperiment" $ do
       it "updates the name of a sub-experiment to the given one" $ runTestEdna do
         resp <- setNameSubExperiment sampleSubExpId "newName"
@@ -120,16 +64,167 @@ spec = withContext $ do
       it "can't delete primary sub-experiment" $ \ctx -> do
         runRIO ctx (deleteSubExperiment sampleSubExpId) `shouldThrow`
           (== DECantDeletePrimary sampleSubExpId)
+      it "fails for unknown sub-experiment" $ \ctx -> do
+        runRIO ctx (deleteSubExperiment unknownSqlId) `shouldThrow`
+          (== DESubExperimentNotFound unknownSqlId)
+      it "successfully deletes non-primary sub-experiment" $ \ctx -> do
+        runRIO ctx (deleteSubExperiment secondarySubExpId >> getSubExperiment secondarySubExpId)
+          `shouldThrow`
+          (== DESubExperimentNotFound secondarySubExpId)
+    describe "newSubExperiment & analyseNewSubExperiment" $ do
+      it "successfully computes and creates a new sub-experiment" $ runTestEdna $ do
+        let changedMeasurement = 1
+        let sourceSubExp = SqlId 1
+        let nser = NewSubExperimentReq
+              { nserName = "newSubExperiment"
+              , nserChanges = one (SqlId changedMeasurement)
+              }
+        let
+          step :: Word32 -> Measurement -> WithId 'MeasurementId MeasurementResp
+          step i m = WithId (SqlId i) MeasurementResp
+            { mrConcentration = mConcentration m
+            , mrSignal = mSignal m
+            , mrIsEnabled = (i == changedMeasurement) == mIsOutlier m
+            }
+        let expectedMeasurements = zipWith step [1..] [m1, m2, m3]
+
+        let activePoints =
+              flip mapMaybe expectedMeasurements $ \(wItem -> measResp) ->
+                guard (mrIsEnabled measResp) $>
+                (mrConcentration measResp, mrSignal measResp)
+
+        (analysedRemovals, analysedResult) <-
+          analyseNewSubExperiment sourceSubExp nser
+        WithId newId resp <- newSubExperiment sourceSubExp nser
+        WithId _ resp' <- getSubExperiment newId
+        measurements <- getMeasurements newId
+        liftIO $ do
+          params4PL <- analyse4PL activePoints
+          analysedResult `shouldBe` params4PL
+          analysedRemovals `shouldBe` [SqlId changedMeasurement]
+
+          resp `shouldBe` resp'
+          serName resp `shouldBe` nserName nser
+          serIsSuspicious resp `shouldBe` False
+          serResult resp `shouldBe` params4PL
+          measurements `shouldBe` expectedMeasurements
   where
     addSampleData = do
       addSampleProjects
       addSampleMethodologies
-      uploadFileTest (SqlId 2) (SqlId 1) sampleFile
       uploadFileTest (SqlId 1) (SqlId 1) sampleFile
+      uploadFileTest (SqlId 2) (SqlId 1) sampleFile
+      newSubExperiment (SqlId 1) NewSubExperimentReq
+        { nserName = "qwe"
+        , nserChanges = mempty
+        }
 
-    sampleSubExpId, unknownSubExpId :: SubExperimentId
+    sampleSubExpId :: SubExperimentId
     sampleSubExpId = SqlId 1
-    unknownSubExpId = SqlId 100
 
-    validSubExperimentIds :: [SubExperimentId]
-    validSubExperimentIds = map SqlId [1 .. 6]
+    -- non-primary
+    secondarySubExpId :: SubExperimentId
+    secondarySubExpId = SqlId 13
+
+gettersSpec :: SpecWith EdnaContext
+gettersSpec = do
+  describe "getters" $ do
+    describe "getExperiments" $ do
+      it "returns all experiments and no IC50 with no filters" $ runTestEdna $ do
+        ExperimentsResp {..} <- getExperiments Nothing Nothing Nothing
+        liftIO $ do
+          length erExperiments `shouldBe` 12
+          erMeanIC50 `shouldBe` Nothing
+      it "filters by project correctly" $ runTestEdna $ do
+        ExperimentsResp {..} <- getExperiments (Just $ SqlId 1) Nothing Nothing
+        liftIO $ do
+          length erExperiments `shouldBe` 6
+          erMeanIC50 `shouldBe` Nothing
+          forM_ erExperiments $ \(WithId _ ExperimentResp {..}) ->
+            erProject `shouldBe` SqlId 1
+      it "filters by project and compound correctly" $ runTestEdna $ do
+        let compoundId = SqlId 2
+        ExperimentsResp {..} <-
+          getExperiments (Just $ SqlId 1) (Just compoundId) Nothing
+        liftIO $ do
+          length erExperiments `shouldBe` 2
+          erMeanIC50 `shouldBe` Nothing
+          forM_ erExperiments $ \(WithId _ ExperimentResp {..}) ->
+            erCompound `shouldBe` compoundId
+      it "filters by 3 filters correctly and returns mean IC50" $ runTestEdna $ do
+        let compoundId = SqlId 2
+        let targetId = SqlId 2
+        ExperimentsResp {..} <-
+          getExperiments (Just $ SqlId 1) (Just compoundId) (Just targetId)
+        liftIO $ do
+          length erExperiments `shouldBe` 1
+          erMeanIC50 `shouldBe` Just 3
+          forM_ erExperiments $ \(WithId _ ExperimentResp {..}) ->
+            erTarget `shouldBe` targetId
+    describe "getExperimentMetadata" $ do
+      it "returns correct metadata for all known experiments" $ runTestEdna $ do
+        forM_ validExperimentIds $ \expId -> do
+          let expectedMetadata =
+                ExperimentMetadata sampleDescription (unFileMetadata sampleMetadata)
+          metadata <- getExperimentMetadata expId
+          liftIO $ metadata `shouldBe` expectedMetadata
+      it "fails for unknown experiment" $ \ctx -> do
+        runRIO ctx (getExperimentMetadata unknownSqlId) `shouldThrow`
+          (== DEExperimentNotFound unknownSqlId)
+    describe "getExperimentFile" $ do
+      it "returns correct file name and blob for all known experiments" $ runTestEdna $ do
+        forM_ validExperimentIds $ \expId -> do
+          let expectedPair =
+                (sampleFileName, ExperimentFileBlob sampleFileBlob)
+          filePair <- getExperimentFile expId
+          liftIO $ filePair `shouldBe` expectedPair
+      it "fails for unknown experiment" $ \ctx -> do
+        runRIO ctx (getExperimentFile unknownSqlId) `shouldThrow`
+          (== DEExperimentNotFound unknownSqlId)
+    describe "getSubExperiment" $ do
+      it "returns correct results for sub-experiments 1-6" $ runTestEdna $ do
+        resps <- forM validSubExperimentIds $ \subExpId -> do
+          WithId gotId gotResp <- getSubExperiment subExpId
+          liftIO $ gotId `shouldBe` subExpId
+          return gotResp
+        -- Very simple check
+        liftIO $ forM_ resps $ \resp ->
+          resp `shouldSatisfy` ((False == ) . serIsSuspicious)
+      it "fails for unknown sub-experiment" $ \ctx -> do
+        runRIO ctx (getSubExperiment unknownSqlId) `shouldThrow`
+          (== DESubExperimentNotFound unknownSqlId)
+    describe "getMeasurements" $ do
+      it "returns correct measurements for sub-experiments 7-13" $ runTestEdna $ do
+        [ measurements1
+          , measurements2
+          , measurements3
+          , measurements4
+          , measurements5
+          , measurements6
+          , measurements7
+          ] <- mapM ((wItem <<$>>) . getMeasurements) (drop 6 validSubExperimentIds)
+        let
+          toMeasurementResp :: Measurement -> MeasurementResp
+          toMeasurementResp Measurement {..} = MeasurementResp
+            { mrConcentration = mConcentration
+            , mrSignal = mSignal
+            , mrIsEnabled = not mIsOutlier
+            }
+        -- These lists match lists in @targetMeasurementsX@ values from SampleData.
+        liftIO $ do
+          measurements1 `shouldBe` map toMeasurementResp [m1, m2, m3]
+          measurements2 `shouldBe` map toMeasurementResp [m2, m4, m5]
+          measurements3 `shouldBe` map toMeasurementResp [m1, m3, m4]
+          measurements4 `shouldBe` map toMeasurementResp [m1, m2, m5]
+          measurements5 `shouldBe` map toMeasurementResp [m1, m5]
+          measurements6 `shouldBe` map toMeasurementResp [m3, m4, m5]
+          measurements7 `shouldBe` measurements1 -- no changes
+      it "fails for unknown sub-experiment" $ \ctx -> do
+        runRIO ctx (getMeasurements unknownSqlId) `shouldThrow`
+          (== DESubExperimentNotFound unknownSqlId)
+
+validSubExperimentIds :: [SubExperimentId]
+validSubExperimentIds = map SqlId [1 .. 13]
+
+validExperimentIds :: [ExperimentId]
+validExperimentIds = map SqlId [1 .. 12]

--- a/backend/test/Test/Gen.hs
+++ b/backend/test/Test/Gen.hs
@@ -40,6 +40,7 @@ module Test.Gen
 import Universum
 
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.HashSet as HS
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Gen.QuickCheck as HQC
 import qualified Hedgehog.Range as Range
@@ -146,6 +147,12 @@ genTargetResp = do
   trProjects <- Gen.list (Range.linear 0 5) genName
   trAdditionDate <- genUTCTime
   return TargetResp {..}
+
+genNewSubExperimentReq :: MonadGen m => m NewSubExperimentReq
+genNewSubExperimentReq =
+  NewSubExperimentReq
+  <$> genName
+  <*> (HS.fromList <$> Gen.list (Range.linear 0 5) genSqlId)
 
 genExperimentsResp :: MonadGen m => m ExperimentsResp
 genExperimentsResp =
@@ -298,6 +305,9 @@ instance Arbitrary CompoundResp where
 
 instance Arbitrary TargetResp where
   arbitrary = hedgehog genTargetResp
+
+instance Arbitrary NewSubExperimentReq where
+  arbitrary = hedgehog genNewSubExperimentReq
 
 instance Arbitrary ExperimentsResp where
   arbitrary = hedgehog genExperimentsResp

--- a/backend/test/Test/Gen.hs
+++ b/backend/test/Test/Gen.hs
@@ -24,6 +24,7 @@ module Test.Gen
   , genExperimentResp
   , genSubExperimentResp
   , genMeasurementResp
+  , genExperimentMetadata
   , genName
   , genURI
   , genDescription
@@ -185,6 +186,12 @@ genMeasurementResp = do
   mrIsEnabled <- Gen.bool
   return MeasurementResp {..}
 
+genExperimentMetadata :: MonadGen m => m ExperimentMetadata
+genExperimentMetadata = do
+  emDescription <- genDescription
+  FileMetadata emFileMetadata <- genFileMetadata
+  return ExperimentMetadata {..}
+
 genFileContents :: MonadGen m => m Text -> m Text -> m FileContents
 genFileContents genTargetName genCompoundName = do
   fcMeasurements <- genFileMeasurements genTargetName genCompoundName
@@ -320,6 +327,9 @@ instance Arbitrary SubExperimentResp where
 
 instance Arbitrary MeasurementResp where
   arbitrary = hedgehog genMeasurementResp
+
+instance Arbitrary ExperimentMetadata where
+  arbitrary = hedgehog genExperimentMetadata
 
 -- Is needed for swagger tests
 instance Arbitrary Text where

--- a/backend/test/Test/SampleData.hs
+++ b/backend/test/Test/SampleData.hs
@@ -19,6 +19,9 @@ module Test.SampleData
   , sampleFile
   , sampleFile2
   , sampleMetadata
+  , sampleDescription
+  , sampleFileName
+  , sampleFileBlob
   -- ↓ Violating style guide a bit, hopefully that's ok ↓
   , targetName1, targetName2, targetName3, targetName4
   , compoundName1, compoundName2, compoundName3, compoundName4, compoundName5
@@ -158,6 +161,15 @@ m5 = Measurement
 sampleMetadata :: FileMetadata
 sampleMetadata = FileMetadata ["foo", "room", "mood"]
 
+sampleDescription :: Text
+sampleDescription = "descr"
+
+sampleFileName :: Text
+sampleFileName = "file"
+
+sampleFileBlob :: LByteString
+sampleFileBlob = BSL.singleton 228
+
 ----------------
 -- Miscellaneous
 ----------------
@@ -192,4 +204,5 @@ addSampleMethodologies =
 -- | Upload file with dummy metadata, bytes and description.
 uploadFileTest :: ProjectId -> MethodologyId -> FileContents -> Edna ()
 uploadFileTest projectId methodologyId =
-  void . Upload.uploadFile' projectId methodologyId "descr" "name" BSL.empty
+  void . Upload.uploadFile' projectId methodologyId sampleDescription
+  sampleFileName sampleFileBlob


### PR DESCRIPTION
## Description

Problem: currently `edna-server` doesn't expose any way to create a new sub-experiment via its API.
Also there is no way to get experimental data file (it should be possible to download them) and metadata.

Solution:
1. Add a new endpoint to create sub-experiments.
2. Also add a similar one to compute 4PL parameters without saving a new sub-experiment.
3. Update `getMeasurements` to return IDs along with measurements
because sub-experiment creation endpoint takes measurement IDs as
argument.
4. Add endpoints to get metadata and raw experiment data file.

## Related issue(s)

https://issues.serokell.io/issue/EDNA-73

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
