### PR TITLE
Use semantic hostnames for deployment

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,11 +40,11 @@ steps:
   - wait
   - label: Deploy staging
     commands:
-      - nix-shell --run 'deploy .#castor'
+      - nix-shell --run 'deploy .#staging'
     branches: "master"
   - label: Deploy demo
     commands:
-      - nix-shell --run 'deploy .#jishui'
+      - nix-shell --run 'deploy .#demo'
     branches: "demo"
   - label: Push backend image to registry
     commands:

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
             path = docker-frontend; }
           ];
       in {
-        hostname = "${hostName}.gemini.serokell.team";
+        hostname = "${hostName}.edna.serokell.team";
         sshOpts = [ "-p" "17788" ];
         profiles.edna-docker = {
           sshUser = "deploy";
@@ -55,8 +55,8 @@
     # Do not roll back profile closure deployment
     deploy.magicRollback = false;
 
-    deploy.nodes.castor = mkEdnaNode "castor";
-    deploy.nodes.jishui = mkEdnaNode "jishui";
+    deploy.nodes.staging = mkEdnaNode "staging";
+    deploy.nodes.demo = mkEdnaNode "demo";
 
     checks = mapAttrs (_: lib: lib.deployChecks self.deploy) deploy-rs.lib;
   })


### PR DESCRIPTION
All our machine have unique internal canonical names, along with
semantic CNAME for the purpose they serve. We've decided to use semantic
names everywhere except internal infrastructure code, so the deployment
flake needs to be updated to reflect that.
