### PR TITLE
[EDNA-92] Docker: Allow backend to print unicode characters

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -1,6 +1,8 @@
 { dockerTools
 , backend
 , frontend
+, locale
+, glibcLocales
 , linkFarm
 , runCommand
 , writeTextDir }:
@@ -24,10 +26,19 @@ in
     contents = [
       backend
       init-sql
+
+      # Unicode support
+      locale
+      glibcLocales
     ];
 
     config = {
       Entrypoint = "/bin/edna-server";
+      Env = [
+        "LANG=en_US.UTF-8"
+        "LC_ALL=en_US.UTF-8"
+        "LOCALE_ARCHIVE=/lib/locale/locale-archive"
+      ];
     };
   };
 


### PR DESCRIPTION
## Description

Backend container would print `?` in place of unicode characters in logs. This was due to a lack of locale archives and not setting a UTF-8 capable locale in the container environment.

I've added glibc locale archives and set `en_US.UTF-8` as active locale. This can be overridden via `-E` flag when creating the container if desired.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-92

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
