### PR TITLE
Make plots more sleek

### DIFF
--- a/frontend/src/pages/dashboard/Plotting/Plotting.tsx
+++ b/frontend/src/pages/dashboard/Plotting/Plotting.tsx
@@ -13,7 +13,7 @@ import { PlotMarker } from "plotly.js-basic-dist";
 import { EmptyPlaceholder } from "../../../components/EmptyPlaceholder/EmptyPlaceholder";
 import { SuccessSubExperimentWithMeasurements } from "../../../store/types";
 import { newSubexperimentAtom } from "../../../store/atoms";
-import { isDefined } from "../../../utils/utils";
+import { isDefined, logspace } from "../../../utils/utils";
 
 const plotConfig: Partial<PlotlyBasic.Config> = {
   displaylogo: false,
@@ -105,12 +105,15 @@ export default function PlotlyChart({
   });
 
   const plTraces: Plotly.Data[] = subExperiments.map(({ subexperiment, color }) => {
+    const x = logspace(
+      subexperiment.measurements[0].item.concentration,
+      subexperiment.measurements[subexperiment.measurements.length - 1].item.concentration,
+      1000
+    );
     return {
       name: "4PL",
-      x: subexperiment.measurements.map(a => a.item.concentration),
-      y: subexperiment.measurements.map(a =>
-        fourPL(subexperiment.meta.item.result.Right, a.item.concentration)
-      ),
+      x,
+      y: x.map(a => fourPL(subexperiment.meta.item.result.Right, a)),
       type: "scatter",
       mode: "lines",
       marker: { color },

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -70,3 +70,17 @@ export function useClickOutsideCallback(ref: RefObject<HTMLElement>, onOutside: 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref]);
 }
+
+export function linspace(start: number, stop: number, len: number): number[] {
+  const step = (stop - start) / (len - 1);
+  return Array.from({ length: len }, (_, i) => start + step * i);
+}
+
+export function logspace(start: number, stop: number, len: number): number[] {
+  const startPoint = Math.log10(start);
+  const endPoint = Math.log10(stop);
+
+  const linPoints = linspace(startPoint, endPoint, len);
+
+  return Array.from(linPoints, (p: number) => 10 ** p);
+}


### PR DESCRIPTION
Problem: curve was drawing only by base points, but it looks bad

Solution: generate 1000 points with log scale and compute 4pl for them

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-107

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
