### PR TITLE
[EDNA-115] Include primary IC50 into ExperimentResp

### DIFF
--- a/backend/src/Edna/Dashboard/Web/Types.hs
+++ b/backend/src/Edna/Dashboard/Web/Types.hs
@@ -78,6 +78,11 @@ data ExperimentResp = ExperimentResp
   -- Usually their number is small (≤2, maybe 3).
   , erPrimarySubExperiment :: SubExperimentId
   -- ^ Idenfitier of the primary sub-experiment from this experiment.
+  , erPrimaryIC50 :: Either Text Double
+  -- ^ IC50 value computed for the primary sub-experiment. It's provided here
+  -- as an optimization. It's possible to get this value by querying sub-experiment
+  -- data (since @erPrimarySubExperiment@) is provided, but it would work slower.
+  -- @Left err@ may be provided if analysis failed for the primary sub-experiment.
   } deriving stock (Generic, Show)
 
 instance Buildable ExperimentResp where
@@ -85,7 +90,8 @@ instance Buildable ExperimentResp where
     "Project " +| erProject |+ ", compound " +| erCompound |+ ", target " +| erTarget |+
     ", methodology " +| erMethodology |+ ", upload date: " +| iso8601Show erUploadDate |+
     ", sub-experiments: " +| map unSqlId erSubExperiments |+
-    ", primary: " +| erPrimarySubExperiment |+ ""
+    ", primary: " +| erPrimarySubExperiment |+
+    ", IC50: " +| either build build erPrimaryIC50 |+ ""
 
 instance Buildable (ForResponseLog ExperimentResp) where
   build = buildForResponse

--- a/backend/test/Test/DashboardSpec.hs
+++ b/backend/test/Test/DashboardSpec.hs
@@ -165,6 +165,9 @@ gettersSpec = do
         Right Params4PL {..} <- analyse4PLOne (mapMaybe measurementToPairMaybe measurements)
         liftIO $ do
           length erExperiments `shouldBe` 1
+          -- It's checked above for better error message
+          let [WithId _ expResp] = erExperiments
+          erPrimaryIC50 expResp `shouldBe` Right p4plC
           erMeanIC50 `shouldBe` Just p4plC
           forM_ erExperiments $ \(WithId _ ExperimentResp {..}) -> do
             erTarget `shouldBe` targetId

--- a/backend/test/Test/Gen.hs
+++ b/backend/test/Test/Gen.hs
@@ -182,6 +182,7 @@ genExperimentResp = do
   erUploadDate <- genUTCTime
   erSubExperiments <- Gen.list (Range.linear 1 5) genSqlId
   erPrimarySubExperiment <- Gen.element erSubExperiments
+  erPrimaryIC50 <- Gen.either genDescription genDoubleSmallPrec
   return ExperimentResp {..}
 
 genSubExperimentResp :: MonadGen m => m SubExperimentResp

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -26,12 +26,12 @@ export type ParsedExcelDto = {
   compounds: ParsedCompoundDto[];
 };
 
-export type ResultDto =
+export type ResultDto<T = number[]> =
   | {
       Left: string;
     }
   | {
-      Right: number[];
+      Right: T;
     };
 
 export type SubExperimentDto = Dto<{
@@ -99,6 +99,7 @@ export type ExperimentDto = Dto<{
   uploadDate: DateTimeDto;
   subExperiments: number[];
   primarySubExperiment: number;
+  primaryIC50: ResultDto<number>;
 }>;
 
 export type ExperimentsWithMeanDto = {

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -94,7 +94,7 @@ export function Table<T extends object>({
                   );
                 })}
               </tr>
-              {collapsible && (
+              {collapsible && shownColl[i] && (
                 <tr>
                   <td
                     colSpan={columns.length}

--- a/frontend/src/pages/dashboard/ExperimentsTable/ExperimentsTable.tsx
+++ b/frontend/src/pages/dashboard/ExperimentsTable/ExperimentsTable.tsx
@@ -91,12 +91,10 @@ export function ExperimentsTableSuspendable({
     () => ({
       Header: "IC50",
       accessor: (e: Experiment) =>
-        "Right" in e.primarySubExperiment.item.result ? (
-          <Tooltip text={`${e.primarySubExperiment.item.result.Right[2]}`}>
-            {formatIC50(e.primarySubExperiment.item.result.Right[2])}
-          </Tooltip>
+        "Right" in e.primaryIC50 ? (
+          <Tooltip text={`${e.primaryIC50.Right}`}>{formatIC50(e.primaryIC50.Right)}</Tooltip>
         ) : (
-          <Tooltip text={e.primarySubExperiment.item.result.Left} type="error">
+          <Tooltip text={e.primaryIC50.Left} type="error">
             <span className="ic50__valueNone" />
           </Tooltip>
         ),
@@ -120,7 +118,7 @@ export function ExperimentsTableSuspendable({
               checked={selectedExperiments.has(exp.id)}
               onChange={e => {
                 if (e.target.checked) {
-                  addSubExperiment(exp.primarySubExperiment.id);
+                  addSubExperiment(exp.primarySubExperimentId);
                 } else {
                   removeSubExperiments(exp.subExperiments);
                 }
@@ -284,7 +282,7 @@ function ExperimentsCollapse({
         <SubexperimentPlate
           className={experimentsTable("subexperiment", { expanded })}
           key={uuidv4()}
-          isPrimary={experiment.primarySubExperiment.id === s.id}
+          isPrimary={experiment.primarySubExperimentId === s.id}
           subexperiment={s}
         />
       ))}

--- a/frontend/src/store/selectors.ts
+++ b/frontend/src/store/selectors.ts
@@ -150,7 +150,8 @@ export const filteredExperimentsQuery = selector<ExperimentsWithMean>({
           methodologyName,
           uploadDate: e.item.uploadDate,
           subExperiments: e.item.subExperiments,
-          primarySubExperiment: get(subExperimentsMetaAtom(e.item.primarySubExperiment)),
+          primarySubExperimentId: e.item.primarySubExperiment,
+          primaryIC50: e.item.primaryIC50,
         };
       })
       .filter(

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -13,6 +13,7 @@ import {
   MeasurementDto,
   DateTimeDto,
   SuccessSubExperimentDto,
+  ResultDto,
 } from "../api/types";
 
 export interface Experiment {
@@ -23,7 +24,8 @@ export interface Experiment {
   methodologyName?: string;
   uploadDate: DateTimeDto;
   subExperiments: number[];
-  primarySubExperiment: SubExperimentDto;
+  primarySubExperimentId: number;
+  primaryIC50: ResultDto<number>;
 }
 
 export type ExperimentsWithMean = {


### PR DESCRIPTION
## Description

Problem: in order to show Dashboard table we query ExperimentsResp
    first and then for each experiment in the response we query its primary
    sub-experiment one-by-one. It's a bit inefficient and we can easily
    decrease number of HTTP endpoint calls.
    
Solution:
1. Add a new field to `ExperimentResp` that holds IC50 computed for the primary sub-experiment. Experiment getter was already querying all sub-experiments, so adding this data to response is pretty straightforward.
2. Update frontend types with this new field and update logic accordingly.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-115

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
