### PR TITLE
Add backend-supported sorting in Table

### DIFF
--- a/frontend/.stylelintrc.js
+++ b/frontend/.stylelintrc.js
@@ -11,7 +11,7 @@ module.exports = {
     "color-named": "always-where-possible",
     "selector-class-pattern": null, // TODO camelCase regexp
     "property-no-vendor-prefix": null,
-    "unit-allowed-list": ["rem", "%", "ms", "s", "vh", "vw", "turn", "fr", "em"],
+    "unit-allowed-list": ["rem", "%", "ms", "s", "vh", "vw", "turn", "fr", "em", "deg"],
     "order/properties-alphabetical-order": null,
     // "declaration-no-important": true, TODO make this rule work
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,57 +6,28 @@ import React, { FunctionComponent, ReactElement, useEffect } from "react";
 import { Route, Switch, useLocation } from "react-router-dom";
 import { Redirect } from "react-router";
 
-import { useRecoilCallback, useRecoilValue, useResetRecoilState, useSetRecoilState } from "recoil";
+import { useRecoilValue, useResetRecoilState } from "recoil";
 import { UploadPage } from "./pages/upload/UploadPage";
 import { LibraryPage } from "./pages/library/LibraryPage";
 import { NotFound } from "./components/NotFound/NotFound";
-import {
-  colorsCounterAtom,
-  compoundIdSelectedAtom,
-  excelFileAtom,
-  experimentsTableSizeAtom,
-  modalDialogAtom,
-  newSubexperimentAtom,
-  projectSelectedIdAtom,
-  selectedSubExperimentsColorAtom,
-  selectedSubExperimentsIdsAtom,
-  targetIdSelectedAtom,
-} from "./store/atoms";
+import { excelFileAtom, modalDialogAtom } from "./store/atoms";
 import { CreateMethodologyDialog } from "./components/dialogs/CreateMethodologyDialog";
 import { CreateProjectDialog } from "./components/dialogs/CreateProjectDialog";
 import { MethodologyDescriptionDialog } from "./components/dialogs/MethodologyDescriptionDialog";
 import { DeleteMethodologyDialog } from "./components/dialogs/DeleteMethodologyDialog";
 import { AddLinkDialog } from "./components/dialogs/AddLinkDialog";
 import { DashboardPage } from "./pages/dashboard/DashboardPage";
-import { chartColors } from "./store/types";
 import { SimpleDialog } from "./components/dialogs/SimpleDialog";
 import { RenameSubexperimentDialog } from "./components/dialogs/RenameSubexperimentDialog";
 import { DeleteSubexperimentDialog } from "./components/dialogs/DeleteSubexperimentDialog";
+import { useDashboardRefresher, useLibraryRefresher } from "./store/updaters";
 
 export const App: FunctionComponent = (): ReactElement => {
   const modalDialog = useRecoilValue(modalDialogAtom);
   const location = useLocation();
   const resetExcelFile = useResetRecoilState(excelFileAtom);
-  const resetProjectSelectedId = useResetRecoilState(projectSelectedIdAtom);
-  const resetCompoundIdSelected = useResetRecoilState(compoundIdSelectedAtom);
-  const resetTargetIdSelected = useResetRecoilState(targetIdSelectedAtom);
-  const resetExperimentsTableSizeAtom = useResetRecoilState(experimentsTableSizeAtom);
-  const resetNewSubExperiment = useResetRecoilState(newSubexperimentAtom);
-  const setSelectedSubExperimentsIds = useSetRecoilState(selectedSubExperimentsIdsAtom);
-  const selectedSubExperiments = useRecoilValue(selectedSubExperimentsIdsAtom);
-
-  const resetColorsCounter = useRecoilCallback(({ reset }) => () => {
-    for (let i = 0; i < chartColors.length; i++) {
-      reset(colorsCounterAtom(chartColors[i]));
-    }
-  });
-
-  const resetSubexperimentsColors = useRecoilCallback(({ reset }) => () => {
-    const arr = Array.from(selectedSubExperiments);
-    for (let i = 0; i < arr.length; i++) {
-      reset(selectedSubExperimentsColorAtom(arr[i]));
-    }
-  });
+  const libraryRefesher = useLibraryRefresher();
+  const dashboardRefresher = useDashboardRefresher();
 
   useEffect(() => {
     // Cleaners of state when we leave a page
@@ -65,15 +36,11 @@ export const App: FunctionComponent = (): ReactElement => {
     }
 
     if (location.pathname !== "/dashboard") {
-      resetColorsCounter();
-      resetSubexperimentsColors();
-      resetProjectSelectedId();
-      resetCompoundIdSelected();
-      resetTargetIdSelected();
-      resetNewSubExperiment();
-      resetExperimentsTableSizeAtom();
-      // For some weird reason reset doesn't update selectedExperimentsQuery selector
-      setSelectedSubExperimentsIds(new Set<number>());
+      dashboardRefresher();
+    }
+
+    if (!location.pathname.startsWith("/library")) {
+      libraryRefesher();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname]);

--- a/frontend/src/api/EdnaApi.ts
+++ b/frontend/src/api/EdnaApi.ts
@@ -50,6 +50,11 @@ export interface AnalyzeNewSubexperimentApi {
   changes: number[];
 }
 
+export type SortParamsApi = {
+  sortby?: string;
+  desc?: boolean;
+};
+
 export function toCreateProjectArgsApi(form: CreateProjectForm): CreateProjectArgsApi {
   return {
     name: form.name,
@@ -65,14 +70,14 @@ interface EdnaApiInterface {
 
   uploadExperiments(form: UploadExperimentsArgsApi): Promise<ParsedExcelDto[]>;
 
-  fetchProjects: () => Promise<ProjectDto[]>;
+  fetchProjects: (params: SortParamsApi) => Promise<ProjectDto[]>;
   createProject: (args: CreateProjectArgsApi) => Promise<ProjectDto>;
   editProject: (projId: number, args: CreateProjectArgsApi) => Promise<ProjectDto>;
-  fetchTargets: () => Promise<TargetDto[]>;
-  fetchCompounds: () => Promise<CompoundDto[]>;
+  fetchTargets: (params: SortParamsApi) => Promise<TargetDto[]>;
+  fetchCompounds: (params: SortParamsApi) => Promise<CompoundDto[]>;
   updateChemSoftLink: (compoundId: number, newLink: string) => Promise<any>;
   updateMdeLink: (compoundId: number, newLink: string) => Promise<any>;
-  fetchMethodologies: () => Promise<MethodologyDto[]>;
+  fetchMethodologies: (params: SortParamsApi) => Promise<MethodologyDto[]>;
   createMethodology: (args: CreateMethodologyArgsApi) => Promise<MethodologyDto>;
   editMethodology: (methId: number, args: CreateMethodologyArgsApi) => Promise<MethodologyDto>;
   deleteMethodology: (methId: number) => Promise<any>;
@@ -80,7 +85,8 @@ interface EdnaApiInterface {
   fetchExperiments: (
     projectId?: number,
     compoundId?: number,
-    targetId?: number
+    targetId?: number,
+    params?: SortParamsApi
   ) => Promise<ExperimentsWithMeanDto>;
   fetchSubExperiment: (subExperimentId: number) => Promise<SubExperimentDto>;
   fetchMeasurements: (subExperimentId: number) => Promise<MeasurementDto[]>;
@@ -107,8 +113,15 @@ interface EdnaApiInterface {
 
 export default function EdnaApi(axios: AxiosInstance): EdnaApiInterface {
   return {
-    fetchCompounds: async (): Promise<CompoundDto[]> => {
-      return axios.get("/compounds").then(proj => proj.data);
+    fetchCompounds: async (params: SortParamsApi): Promise<CompoundDto[]> => {
+      return axios
+        .get("/compounds", {
+          params: {
+            // TODO expand other fields
+            sortby: params.sortby,
+          },
+        })
+        .then(proj => proj.data);
     },
 
     updateChemSoftLink: async (compoundId: number, newLink: string): Promise<any> => {
@@ -127,8 +140,15 @@ export default function EdnaApi(axios: AxiosInstance): EdnaApiInterface {
         .then(proj => proj.data);
     },
 
-    fetchTargets: async (): Promise<TargetDto[]> => {
-      return axios.get("/targets").then(proj => proj.data);
+    fetchTargets: async (params: SortParamsApi): Promise<TargetDto[]> => {
+      return axios
+        .get("/targets", {
+          params: {
+            // TODO expand other fields
+            sortby: params.sortby,
+          },
+        })
+        .then(proj => proj.data);
     },
 
     parseExcelFile: async (
@@ -187,8 +207,15 @@ export default function EdnaApi(axios: AxiosInstance): EdnaApiInterface {
         });
     },
 
-    fetchProjects: async () => {
-      return axios.get("/projects").then(proj => proj.data);
+    fetchProjects: async (params?: SortParamsApi) => {
+      return axios
+        .get("/projects", {
+          params: {
+            // TODO expand other fields
+            sortby: params?.sortby,
+          },
+        })
+        .then(proj => proj.data);
     },
 
     createMethodology: async (args: CreateMethodologyArgsApi) => {
@@ -218,17 +245,31 @@ export default function EdnaApi(axios: AxiosInstance): EdnaApiInterface {
         });
     },
 
-    fetchMethodologies: async () => {
-      return axios.get("/methodologies").then(proj => proj.data);
+    fetchMethodologies: async (params: SortParamsApi) => {
+      return axios
+        .get("/methodologies", {
+          params: {
+            // TODO expand other fields
+            sortdy: params.sortby,
+          },
+        })
+        .then(proj => proj.data);
     },
 
-    fetchExperiments: async (projectId?: number, compoundId?: number, targetId?: number) => {
+    fetchExperiments: async (
+      projectId?: number,
+      compoundId?: number,
+      targetId?: number,
+      params?: SortParamsApi
+    ) => {
       return axios
         .get("/experiments", {
           params: {
             projectId,
             compoundId,
             targetId,
+            // TODO expand other fields
+            sortby: params?.sortby,
           },
         })
         .then(experiments => experiments.data);

--- a/frontend/src/api/EdnaApi.ts
+++ b/frontend/src/api/EdnaApi.ts
@@ -55,6 +55,12 @@ export type SortParamsApi = {
   desc?: boolean;
 };
 
+function toApiParams(params: SortParamsApi) {
+  return {
+    sortBy: params.sortby ? (params.desc ? `desc(${params.sortby})` : `asc(${params.sortby})`) : "",
+  };
+}
+
 export function toCreateProjectArgsApi(form: CreateProjectForm): CreateProjectArgsApi {
   return {
     name: form.name,
@@ -116,10 +122,7 @@ export default function EdnaApi(axios: AxiosInstance): EdnaApiInterface {
     fetchCompounds: async (params: SortParamsApi): Promise<CompoundDto[]> => {
       return axios
         .get("/compounds", {
-          params: {
-            // TODO expand other fields
-            sortby: params.sortby,
-          },
+          params: toApiParams(params),
         })
         .then(proj => proj.data);
     },
@@ -143,10 +146,7 @@ export default function EdnaApi(axios: AxiosInstance): EdnaApiInterface {
     fetchTargets: async (params: SortParamsApi): Promise<TargetDto[]> => {
       return axios
         .get("/targets", {
-          params: {
-            // TODO expand other fields
-            sortby: params.sortby,
-          },
+          params: toApiParams(params),
         })
         .then(proj => proj.data);
     },
@@ -207,13 +207,10 @@ export default function EdnaApi(axios: AxiosInstance): EdnaApiInterface {
         });
     },
 
-    fetchProjects: async (params?: SortParamsApi) => {
+    fetchProjects: async (params: SortParamsApi) => {
       return axios
         .get("/projects", {
-          params: {
-            // TODO expand other fields
-            sortby: params?.sortby,
-          },
+          params: toApiParams(params),
         })
         .then(proj => proj.data);
     },
@@ -248,10 +245,7 @@ export default function EdnaApi(axios: AxiosInstance): EdnaApiInterface {
     fetchMethodologies: async (params: SortParamsApi) => {
       return axios
         .get("/methodologies", {
-          params: {
-            // TODO expand other fields
-            sortdy: params.sortby,
-          },
+          params: toApiParams(params),
         })
         .then(proj => proj.data);
     },
@@ -262,14 +256,14 @@ export default function EdnaApi(axios: AxiosInstance): EdnaApiInterface {
       targetId?: number,
       params?: SortParamsApi
     ) => {
+      const sp = params ? toApiParams(params) : {};
       return axios
         .get("/experiments", {
           params: {
             projectId,
             compoundId,
             targetId,
-            // TODO expand other fields
-            sortby: params?.sortby,
+            ...sp,
           },
         })
         .then(experiments => experiments.data);

--- a/frontend/src/assets/svg/arrow.svg
+++ b/frontend/src/assets/svg/arrow.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="12" viewBox="0 0 8 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.5 7.5L3.94975 10.9497M7.5 7.5L3.94975 10.9497M3.94975 10.9497L3.94975 1.05025" stroke="#9BA5A1" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/Spinner/Spinner.tsx
+++ b/frontend/src/components/Spinner/Spinner.tsx
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import "./Spinner.scss";
+import React from "react";
+import cx from "classnames";
+
+export function Spinner({ className }: { className?: string }): React.ReactElement {
+  return <div className={cx("spinner", className)} />;
+}

--- a/frontend/src/components/Table/Table.scss
+++ b/frontend/src/components/Table/Table.scss
@@ -36,6 +36,21 @@ $cell-indent: 22 * $px;
     }
   }
 
+  &__sortSign {
+    margin-left: 22 * $px;
+    visibility: hidden;
+
+    &_desc {
+      svg {
+        transform: rotate(180deg);
+      }
+    }
+
+    &_vis {
+      visibility: visible;
+    }
+  }
+
   &__headRightBorder {
     $height: 20 * $px;
     position: absolute;
@@ -87,6 +102,13 @@ $cell-indent: 22 * $px;
         cursor: pointer;
       }
     }
+  }
+
+  &__error {
+    display: table-cell;
+    padding: 20 * $px;
+    color: $color-help-red;
+    text-align: center;
   }
 
   tr:last-child .ednaTable__cell {

--- a/frontend/src/components/Table/Table.scss
+++ b/frontend/src/components/Table/Table.scss
@@ -16,6 +16,21 @@ $cell-indent: 22 * $px;
   width: 100%;
   border-spacing: 0;
 
+  &__sortSign {
+    margin-left: 22 * $px;
+    visibility: hidden;
+
+    &_desc {
+      svg {
+        transform: rotate(180deg);
+      }
+    }
+
+    &_vis {
+      visibility: visible;
+    }
+  }
+
   &__columnHead {
     position: sticky;
     top: 0;
@@ -34,19 +49,8 @@ $cell-indent: 22 * $px;
     &:last-child {
       border-right: 0;
     }
-  }
 
-  &__sortSign {
-    margin-left: 22 * $px;
-    visibility: hidden;
-
-    &_desc {
-      svg {
-        transform: rotate(180deg);
-      }
-    }
-
-    &_vis {
+    &:hover .ednaTable__sortSign {
       visibility: visible;
     }
   }

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -23,6 +23,7 @@ interface TableProps<T extends object> {
   className?: string;
   small?: boolean;
   collapsible?: (x: T) => React.ReactNode;
+  defaultSortedColumn: string;
   dataOrQuery:
     | RecoilValueReadOnly<ReadonlyArray<T>>
     | ((param: SortParamsApi) => RecoilValueReadOnly<T[]>);
@@ -36,6 +37,7 @@ export function Table<T extends object>({
   small,
   collapsible,
   dataOrQuery,
+  defaultSortedColumn,
 }: TableProps<T>): React.ReactElement {
   const isConstant = isRecoilValue(dataOrQuery);
   const [data, setData] = useState<T[]>([]);
@@ -51,8 +53,16 @@ export function Table<T extends object>({
     {
       columns,
       data,
+      initialState: {
+        sortBy: [
+          {
+            id: defaultSortedColumn,
+          },
+        ],
+      },
       disableMultiSort: true,
       manualSortBy: !isConstant,
+      disableSortRemove: true,
     },
     useSortBy
   );

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -173,14 +173,16 @@ export function Table<T extends object>({
                   title={column.canSort ? `Sort by ${column.Header}` : ""}
                 >
                   {column.render("Header")}
-                  <span
-                    className={ednaTable("sortSign", {
-                      desc: column.isSortedDesc,
-                      vis: column.isSorted,
-                    })}
-                  >
-                    <ArrowSvg />
-                  </span>
+                  {column.canSort && (
+                    <span
+                      className={ednaTable("sortSign", {
+                        desc: column.isSortedDesc,
+                        vis: column.isSorted,
+                      })}
+                    >
+                      <ArrowSvg />
+                    </span>
+                  )}
                   {i <= lastColumnWithRightBorder && (
                     <span className="ednaTable__headRightBorder" />
                   )}

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -2,63 +2,102 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import React, { useState } from "react";
-import { Column, useTable } from "react-table";
+import React, { useEffect, useState } from "react";
+import { Column, useSortBy, useTable } from "react-table";
 import { v4 as uuidv4 } from "uuid";
 import "./Table.scss";
+import { isRecoilValue, RecoilValueReadOnly, useRecoilValueLoadable } from "recoil";
 import cn from "../../utils/bemUtils";
+import ArrowSvg from "../../assets/svg/arrow.svg";
+import { Spinner } from "../Spinner/Spinner";
+import { SortParamsApi } from "../../api/EdnaApi";
 
 interface ColumnExtra {
   manualCellRendering?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-interface LibraryTableProps<T extends object> {
-  data: T[];
+interface TableProps<T extends object> {
   columns: Column<T>[];
   columnExtras?: { [id: string]: ColumnExtra };
   className?: string;
   small?: boolean;
   collapsible?: (x: T) => React.ReactNode;
+  dataOrQuery:
+    | RecoilValueReadOnly<ReadonlyArray<T>>
+    | ((param: SortParamsApi) => RecoilValueReadOnly<T[]>);
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function Table<T extends object>({
-  data,
   columns,
   columnExtras,
   className,
   small,
   collapsible,
-}: LibraryTableProps<T>): React.ReactElement {
-  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = useTable({
-    columns,
-    data,
-  });
+  dataOrQuery,
+}: TableProps<T>): React.ReactElement {
+  const isConstant = isRecoilValue(dataOrQuery);
+  const [data, setData] = useState<T[]>([]);
+
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    rows,
+    prepareRow,
+    state: { sortBy },
+  } = useTable<T>(
+    {
+      columns,
+      data,
+      disableMultiSort: true,
+      manualSortBy: !isConstant,
+    },
+    useSortBy
+  );
+
+  const loadableData = useRecoilValueLoadable(
+    typeof dataOrQuery === "function"
+      ? dataOrQuery(sortBy.length === 0 ? {} : { sortby: sortBy[0].id, desc: sortBy[0].desc })
+      : dataOrQuery
+  );
+
+  useEffect(() => {
+    if (loadableData.state === "hasValue") {
+      setData(loadableData.contents.concat([]));
+    } else {
+      setData([]);
+    }
+  }, [loadableData]);
+
   const isCollapsible = !!collapsible;
   const lastColumnWithRightBorder = computeLastColumnWithRightBorder(columns);
   const ednaTable = cn("ednaTable");
   const [shownColl, setShownColl] = useState<boolean[]>(new Array(data.length).fill(false));
 
-  return (
-    <table {...getTableProps()} className={`ednaTable ${className ?? ""}`}>
-      <thead>
-        {headerGroups.map(headerGroup => (
-          <tr {...headerGroup.getHeaderGroupProps()}>
-            {headerGroup.headers.map((column, i) => {
-              return (
-                <th {...column.getHeaderProps()} className="ednaTable__columnHead">
-                  {column.render("Header")}
-                  {i <= lastColumnWithRightBorder && (
-                    <span className="ednaTable__headRightBorder" />
-                  )}
-                </th>
-              );
-            })}
-          </tr>
-        ))}
-      </thead>
-      <tbody {...getTableBodyProps()}>
+  function renderRows(): React.ReactElement {
+    if (loadableData.state === "loading") {
+      return (
+        <tr>
+          <td colSpan={columns.length}>
+            <Spinner />
+          </td>
+        </tr>
+      );
+    }
+    if (loadableData.state === "hasError") {
+      return (
+        <tr>
+          <td colSpan={columns.length} className="ednaTable__error">
+            {loadableData.contents.message}
+          </td>
+        </tr>
+      );
+    }
+
+    return (
+      <>
         {rows.map((row, i) => {
           prepareRow(row);
           return (
@@ -107,7 +146,41 @@ export function Table<T extends object>({
             </React.Fragment>
           );
         })}
-      </tbody>
+      </>
+    );
+  }
+
+  return (
+    <table {...getTableProps()} className={`ednaTable ${className ?? ""}`}>
+      <thead>
+        {headerGroups.map(headerGroup => (
+          <tr {...headerGroup.getHeaderGroupProps()}>
+            {headerGroup.headers.map((column, i) => {
+              return (
+                <th
+                  {...column.getHeaderProps(column.getSortByToggleProps())}
+                  className="ednaTable__columnHead"
+                  title={column.canSort ? `Sort by ${column.Header}` : ""}
+                >
+                  {column.render("Header")}
+                  <span
+                    className={ednaTable("sortSign", {
+                      desc: column.isSortedDesc,
+                      vis: column.isSorted,
+                    })}
+                  >
+                    <ArrowSvg />
+                  </span>
+                  {i <= lastColumnWithRightBorder && (
+                    <span className="ednaTable__headRightBorder" />
+                  )}
+                </th>
+              );
+            })}
+          </tr>
+        ))}
+      </thead>
+      <tbody {...getTableBodyProps()}>{renderRows()}</tbody>
     </table>
   );
 }

--- a/frontend/src/components/UploadPreviewTable/UploadPreviewTable.tsx
+++ b/frontend/src/components/UploadPreviewTable/UploadPreviewTable.tsx
@@ -96,6 +96,7 @@ export function UploadPreviewTable({
       <Table
         small
         dataOrQuery={constSelector(data)}
+        defaultSortedColumn="compound"
         columns={previewColumns}
         className="uploadPreviewTable"
         columnExtras={{

--- a/frontend/src/components/UploadPreviewTable/UploadPreviewTable.tsx
+++ b/frontend/src/components/UploadPreviewTable/UploadPreviewTable.tsx
@@ -7,6 +7,7 @@ import "./UploadPreviewTable.scss";
 import cx from "classnames";
 import { Column } from "react-table";
 import { Link } from "react-router-dom";
+import { constSelector } from "recoil";
 import { Button } from "../Button/Button";
 import { ParsedExcelDto } from "../../api/types";
 import { Table } from "../Table/Table";
@@ -20,10 +21,11 @@ interface UploadTableProps {
 }
 
 interface PreviewRow {
-  compoundId?: number;
-  compoundName: string;
-  targetId?: number;
-  targetName: string;
+  readonly compoundId?: number;
+  readonly compoundName: string;
+  readonly targetId?: number;
+  readonly targetName: string;
+  [key: string]: any;
 }
 
 export function UploadPreviewTable({
@@ -35,15 +37,18 @@ export function UploadPreviewTable({
     () => [
       {
         Header: "Compound",
+        id: "compound",
         accessor: (p: PreviewRow) => `${p.compoundName} ${p.compoundId ? "" : "*"}`,
       },
       {
         Header: "Target",
+        id: "target",
         accessor: (p: PreviewRow) => `${p.targetName} ${p.targetId ? "" : "*"}`,
       },
 
       {
         id: "actions",
+        disableSortBy: true,
         accessor: (p: PreviewRow) => {
           const disabled = !projectId || !isDefined(p.compoundId) || !isDefined(p.targetId);
           const viewBtn = (
@@ -73,23 +78,24 @@ export function UploadPreviewTable({
     [projectId]
   );
 
-  const data: PreviewRow[] = [];
-  targets.forEach(ex =>
-    ex.compounds.forEach(compound => {
-      data.push({
-        compoundName: compound.name,
-        compoundId: compound.id,
-        targetName: ex.target.name,
-        targetId: ex.target.id,
-      });
-    })
-  );
+  const data: ReadonlyArray<PreviewRow> = targets.reduce((acc: ReadonlyArray<PreviewRow>, ex) => {
+    return ex.compounds.reduce((acc1, compound) => {
+      return acc1.concat([
+        {
+          compoundName: compound.name,
+          compoundId: compound.id,
+          targetName: ex.target.name,
+          targetId: ex.target.id,
+        },
+      ]);
+    }, acc);
+  }, []);
 
   return (
     <div className={cx(["tableContainer", "uploadPreviewTableContainer", className])}>
       <Table
         small
-        data={data}
+        dataOrQuery={constSelector(data)}
         columns={previewColumns}
         className="uploadPreviewTable"
         columnExtras={{

--- a/frontend/src/components/dialogs/CreateProjectDialog.tsx
+++ b/frontend/src/components/dialogs/CreateProjectDialog.tsx
@@ -13,7 +13,7 @@ import Api from "../../api/api";
 import "../RoundSpinner.scss";
 import { CreateDialogFooter, FormState } from "../DialogLayout/CreateDialogFooter";
 import { toCreateProjectArgsApi } from "../../api/EdnaApi";
-import { useProjectRefresher } from "../../store/updaters";
+import { useProjectsRefresher } from "../../store/updaters";
 import { CreateProjectForm, toCreateProjectForm } from "./types";
 import { ProjectDto } from "../../api/types";
 import { DialogLayout } from "../DialogLayout/DialogLayout";
@@ -24,7 +24,7 @@ interface CreateProjectDialogProps {
 
 export function CreateProjectDialog({ editing }: CreateProjectDialogProps): React.ReactElement {
   const setModalDialog = useSetRecoilState(modalDialogAtom);
-  const refreshProjects = useProjectRefresher();
+  const refreshProjects = useProjectsRefresher();
   const [formState, setFormState] = useState<FormState>();
 
   return (

--- a/frontend/src/pages/dashboard/EntitySelector.tsx
+++ b/frontend/src/pages/dashboard/EntitySelector.tsx
@@ -29,7 +29,8 @@ interface SelectorProps {
 }
 
 export function ProjectSelector({ className }: SelectorProps): React.ReactElement {
-  const projectsL = useRecoilValueLoadable(projectsQuery);
+  // TODO make it async one day?
+  const projectsL = useRecoilValueLoadable(projectsQuery({}));
   const projectSelectedL = useRecoilValueLoadable(projectSelectedQuery);
   const setProjectSelected = useSetRecoilState(projectSelectedIdAtom);
   const setModalDialog = useSetRecoilState(modalDialogAtom);
@@ -70,7 +71,8 @@ export function ProjectSelector({ className }: SelectorProps): React.ReactElemen
 }
 
 export function CompoundSelector({ className }: SelectorProps): React.ReactElement {
-  const compoundsL = useRecoilValueLoadable(compoundsQuery);
+  // TODO make it async one day?
+  const compoundsL = useRecoilValueLoadable(compoundsQuery({}));
   const compoundSelectedL = useRecoilValueLoadable(compoundSelectedQuery);
   const setCompoundSelected = useSetRecoilState(compoundIdSelectedAtom);
   const setModalDialog = useSetRecoilState(modalDialogAtom);
@@ -157,7 +159,8 @@ export function CompoundSelector({ className }: SelectorProps): React.ReactEleme
 }
 
 export function TargetSelector({ className }: SelectorProps): React.ReactElement {
-  const targetsLoadable = useRecoilValueLoadable(targetsQuery);
+  // TODO make it async one day?
+  const targetsLoadable = useRecoilValueLoadable(targetsQuery({}));
   const targetSelected = useRecoilValueLoadable(targetSelectedQuery);
   const setTargetSelected = useSetRecoilState(targetIdSelectedAtom);
   return (

--- a/frontend/src/pages/dashboard/ExperimentsTable/ExperimentsTable.tsx
+++ b/frontend/src/pages/dashboard/ExperimentsTable/ExperimentsTable.tsx
@@ -25,7 +25,11 @@ import {
   targetIdSelectedAtom,
 } from "../../../store/atoms";
 import { Table } from "../../../components/Table/Table";
-import { filteredExperimentsDtoQuery, filteredExperimentsQuery } from "../../../store/selectors";
+import {
+  defaultBatchQuery,
+  filteredExperimentsDtoQuery,
+  filteredExperimentsQuery,
+} from "../../../store/selectors";
 import { formatAsDate, formatIC50, isDefined } from "../../../utils/utils";
 import { ContextActions } from "../../../components/ContextActions/ContextActions";
 import { EmptyPlaceholder } from "../../../components/EmptyPlaceholder/EmptyPlaceholder";
@@ -61,7 +65,9 @@ export function ExperimentsTableSuspendable({
   const selectedTargetId = useRecoilValue(targetIdSelectedAtom);
 
   // TODO request here only 1st page to check experiments emptiness
-  const experimentsChunk = useRecoilValue(filteredExperimentsDtoQuery({})).experiments;
+  const experimentsChunk = useRecoilValue(
+    defaultBatchQuery(filteredExperimentsDtoQuery, { sortby: "uploadDate", desc: true })
+  ).experiments;
   const [showEntries, setShowEntries] = useState<ShowEntries>("all");
   const addSubExperiment = useAddSubExperiment();
   const removeSubExperiments = useRemoveSubExperiments();
@@ -102,7 +108,7 @@ export function ExperimentsTableSuspendable({
   const compoundColumn = React.useMemo(
     () => ({
       Header: "Compound",
-      id: "compound",
+      disableSortBy: true,
       accessor: (e: Experiment) => e.compoundName,
     }),
     []
@@ -111,7 +117,7 @@ export function ExperimentsTableSuspendable({
   const targetColumn = React.useMemo(
     () => ({
       Header: "Target",
-      id: "target",
+      disableSortBy: true,
       accessor: (e: Experiment) => e.targetName,
     }),
     []
@@ -120,7 +126,7 @@ export function ExperimentsTableSuspendable({
   const ic50Column = React.useMemo(
     () => ({
       Header: "IC50",
-      id: "ic50",
+      disableSortBy: true,
       accessor: (e: Experiment) =>
         "Right" in e.primaryIC50 ? (
           <Tooltip text={`${e.primaryIC50.Right}`}>{formatIC50(e.primaryIC50.Right)}</Tooltip>
@@ -176,11 +182,12 @@ export function ExperimentsTableSuspendable({
       ic50Column,
       {
         Header: "Methodology",
-        id: "methodology",
+        disableSortBy: true,
         accessor: (e: Experiment) => e.methodologyName,
       },
       {
-        Header: "Upload data",
+        Header: "Upload date",
+        id: "uploadDate",
         accessor: (e: Experiment) => formatAsDate(e.uploadDate),
       },
       showCheckboxColumn,
@@ -234,6 +241,7 @@ export function ExperimentsTableSuspendable({
           </div>
           <div className="tableContainer experimentsArea__experimentsTableContainer">
             <Table<Experiment>
+              defaultSortedColumn="uploadDate"
               small
               columns={expTableSize === "minimized" ? minimizedColumns : expandedColumns}
               dataOrQuery={params => shownExperiments([showEntries, params])}

--- a/frontend/src/pages/dashboard/ExperimentsTable/ExperimentsTable.tsx
+++ b/frontend/src/pages/dashboard/ExperimentsTable/ExperimentsTable.tsx
@@ -30,7 +30,7 @@ import {
   filteredExperimentsDtoQuery,
   filteredExperimentsQuery,
 } from "../../../store/selectors";
-import { formatAsDate, formatIC50, isDefined } from "../../../utils/utils";
+import { formatAsDate, formatAsDateTime, formatIC50, isDefined } from "../../../utils/utils";
 import { ContextActions } from "../../../components/ContextActions/ContextActions";
 import { EmptyPlaceholder } from "../../../components/EmptyPlaceholder/EmptyPlaceholder";
 import { Experiment } from "../../../store/types";
@@ -188,7 +188,9 @@ export function ExperimentsTableSuspendable({
       {
         Header: "Upload date",
         id: "uploadDate",
-        accessor: (e: Experiment) => formatAsDate(e.uploadDate),
+        accessor: (e: Experiment) => (
+          <Tooltip text={formatAsDateTime(e.uploadDate)}>{formatAsDate(e.uploadDate)}</Tooltip>
+        ),
       },
       showCheckboxColumn,
       {

--- a/frontend/src/pages/library/Compounds.tsx
+++ b/frontend/src/pages/library/Compounds.tsx
@@ -15,17 +15,20 @@ import { Table } from "../../components/Table/Table";
 import { ContextItem } from "../../components/ContextActions/ContextItems";
 
 export function CompoundsSuspendable(): React.ReactElement {
-  const compounds = useRecoilValue(compoundsQuery);
+  // TODO request here only 1st page to check compounds emptiness
+  const compoundsChunk = useRecoilValue(compoundsQuery({}));
   const setModalDialog = useSetRecoilState(modalDialogAtom);
   const compoundsColumns = React.useMemo(
     () => [
       {
-        Header: "Compounds",
+        Header: "Compound",
+        id: "name",
         accessor: (c: CompoundDto) => c.item.name,
       },
       {
         Header: "MDe link",
         id: "mde",
+        disableSortBy: true,
         accessor: (c: CompoundDto) => (
           <td className={`ednaTable__cell${c.item.mde ? "" : " libraryTable__cellBtn"}`}>
             {c.item.mde ? (
@@ -49,6 +52,7 @@ export function CompoundsSuspendable(): React.ReactElement {
       },
       {
         Header: "ChemSoft link",
+        disableSortBy: true,
         id: "chemsoft",
         accessor: (c: CompoundDto) => (
           <td className={`ednaTable__cell${c.item.chemSoft ? "" : " libraryTable__cellBtn"}`}>
@@ -73,6 +77,7 @@ export function CompoundsSuspendable(): React.ReactElement {
       },
       {
         id: "actions",
+        disableSortBy: true,
         accessor: (c: CompoundDto) => (
           <ContextActions
             actions={[
@@ -105,7 +110,7 @@ export function CompoundsSuspendable(): React.ReactElement {
     ],
     [setModalDialog]
   );
-  return compounds.length === 0 ? (
+  return compoundsChunk.length === 0 ? (
     <EmptyPlaceholder
       title="No compounds added yet"
       description="To add compounds add new experiments"
@@ -117,7 +122,7 @@ export function CompoundsSuspendable(): React.ReactElement {
     />
   ) : (
     <Table
-      data={compounds}
+      dataOrQuery={compoundsQuery}
       columns={compoundsColumns}
       columnExtras={{
         chemsoft: { manualCellRendering: true },

--- a/frontend/src/pages/library/Compounds.tsx
+++ b/frontend/src/pages/library/Compounds.tsx
@@ -5,7 +5,7 @@
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import React from "react";
 import { Link } from "react-router-dom";
-import { compoundsQuery } from "../../store/selectors";
+import { compoundsQuery, defaultBatchQuery } from "../../store/selectors";
 import { modalDialogAtom } from "../../store/atoms";
 import { CompoundDto } from "../../api/types";
 import { Button } from "../../components/Button/Button";
@@ -16,7 +16,7 @@ import { ContextItem } from "../../components/ContextActions/ContextItems";
 
 export function CompoundsSuspendable(): React.ReactElement {
   // TODO request here only 1st page to check compounds emptiness
-  const compoundsChunk = useRecoilValue(compoundsQuery({}));
+  const compoundsChunk = useRecoilValue(defaultBatchQuery(compoundsQuery));
   const setModalDialog = useSetRecoilState(modalDialogAtom);
   const compoundsColumns = React.useMemo(
     () => [
@@ -123,6 +123,7 @@ export function CompoundsSuspendable(): React.ReactElement {
   ) : (
     <Table
       dataOrQuery={compoundsQuery}
+      defaultSortedColumn="name"
       columns={compoundsColumns}
       columnExtras={{
         chemsoft: { manualCellRendering: true },

--- a/frontend/src/pages/library/Methodologies.tsx
+++ b/frontend/src/pages/library/Methodologies.tsx
@@ -6,7 +6,7 @@ import { useRecoilValue, useSetRecoilState } from "recoil";
 import { Column } from "react-table";
 import React from "react";
 import { modalDialogAtom } from "../../store/atoms";
-import { methodologiesQuery } from "../../store/selectors";
+import { defaultBatchQuery, methodologiesQuery } from "../../store/selectors";
 import { MethodologyDto } from "../../api/types";
 import { Button } from "../../components/Button/Button";
 import { ContextActions } from "../../components/ContextActions/ContextActions";
@@ -18,11 +18,12 @@ import { ExtraFormatter } from "../../components/ExtraFormatter";
 export function MethodsSuspendable(): React.ReactElement {
   const setModalDialog = useSetRecoilState(modalDialogAtom);
   // TODO request here only 1st page to check methodologies emptiness
-  const methodologiesChunk = useRecoilValue(methodologiesQuery({}));
+  const methodologiesChunk = useRecoilValue(defaultBatchQuery(methodologiesQuery));
   const methodologyColumns: Column<MethodologyDto>[] = React.useMemo(
     () => [
       {
         Header: "Methodology",
+        id: "name",
         accessor: (t: MethodologyDto) => t.item.name,
       },
       {
@@ -131,6 +132,7 @@ export function MethodsSuspendable(): React.ReactElement {
     <Table
       dataOrQuery={methodologiesQuery}
       columns={methodologyColumns}
+      defaultSortedColumn="name"
       columnExtras={{
         link: { manualCellRendering: true },
         description: { manualCellRendering: true },

--- a/frontend/src/pages/library/Methodologies.tsx
+++ b/frontend/src/pages/library/Methodologies.tsx
@@ -17,7 +17,8 @@ import { ExtraFormatter } from "../../components/ExtraFormatter";
 
 export function MethodsSuspendable(): React.ReactElement {
   const setModalDialog = useSetRecoilState(modalDialogAtom);
-  const methodologies = useRecoilValue(methodologiesQuery);
+  // TODO request here only 1st page to check methodologies emptiness
+  const methodologiesChunk = useRecoilValue(methodologiesQuery({}));
   const methodologyColumns: Column<MethodologyDto>[] = React.useMemo(
     () => [
       {
@@ -26,10 +27,12 @@ export function MethodsSuspendable(): React.ReactElement {
       },
       {
         Header: "Projects",
+        disableSortBy: true,
         accessor: (t: MethodologyDto) => <ExtraFormatter items={t.item.projects} />,
       },
       {
         Header: "Confluence link",
+        disableSortBy: true,
         id: "link",
         accessor: (m: MethodologyDto) => {
           if (m.item.confluence)
@@ -58,6 +61,7 @@ export function MethodsSuspendable(): React.ReactElement {
       },
       {
         Header: "Description",
+        disableSortBy: true,
         id: "description",
         accessor: (m: MethodologyDto) => {
           return (
@@ -81,6 +85,7 @@ export function MethodsSuspendable(): React.ReactElement {
 
       {
         id: "actions",
+        disableSortBy: true,
         accessor: (m: MethodologyDto) => (
           <ContextActions
             actions={[
@@ -112,7 +117,7 @@ export function MethodsSuspendable(): React.ReactElement {
     [setModalDialog]
   );
 
-  return methodologies.length === 0 ? (
+  return methodologiesChunk.length === 0 ? (
     <EmptyPlaceholder
       title="No methodologies created yet"
       description="All created methodologies will be displayed here"
@@ -124,7 +129,7 @@ export function MethodsSuspendable(): React.ReactElement {
     />
   ) : (
     <Table
-      data={methodologies}
+      dataOrQuery={methodologiesQuery}
       columns={methodologyColumns}
       columnExtras={{
         link: { manualCellRendering: true },

--- a/frontend/src/pages/library/Projects.tsx
+++ b/frontend/src/pages/library/Projects.tsx
@@ -5,7 +5,7 @@
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import React from "react";
 import { modalDialogAtom } from "../../store/atoms";
-import { projectsQuery } from "../../store/selectors";
+import { defaultBatchQuery, projectsQuery } from "../../store/selectors";
 import { ProjectDto } from "../../api/types";
 import { formatAsDate, formatAsDateTime } from "../../utils/utils";
 import { ContextActions } from "../../components/ContextActions/ContextActions";
@@ -19,7 +19,7 @@ import { Tooltip } from "../../components/Tooltip/Tooltip";
 export function ProjectsSuspendable(): React.ReactElement {
   const setModalDialog = useSetRecoilState(modalDialogAtom);
   // TODO request here only 1st page to check projects emptiness
-  const projectsChunk = useRecoilValue(projectsQuery({}));
+  const projectsChunk = useRecoilValue(defaultBatchQuery(projectsQuery));
 
   const projectColumns = React.useMemo(
     () => [
@@ -89,6 +89,6 @@ export function ProjectsSuspendable(): React.ReactElement {
       }
     />
   ) : (
-    <Table dataOrQuery={projectsQuery} columns={projectColumns} />
+    <Table dataOrQuery={projectsQuery} columns={projectColumns} defaultSortedColumn="name" />
   );
 }

--- a/frontend/src/pages/library/Projects.tsx
+++ b/frontend/src/pages/library/Projects.tsx
@@ -18,15 +18,19 @@ import { Tooltip } from "../../components/Tooltip/Tooltip";
 
 export function ProjectsSuspendable(): React.ReactElement {
   const setModalDialog = useSetRecoilState(modalDialogAtom);
-  const projects = useRecoilValue(projectsQuery);
+  // TODO request here only 1st page to check projects emptiness
+  const projectsChunk = useRecoilValue(projectsQuery({}));
+
   const projectColumns = React.useMemo(
     () => [
       {
         Header: "Project",
+        id: "name",
         accessor: (p: ProjectDto) => p.item.name,
       },
       {
         Header: "Compounds",
+        disableSortBy: true,
         accessor: (p: ProjectDto) => (
           <span className="project__compounds">
             <ExtraFormatter items={p.item.compoundNames} />
@@ -35,6 +39,7 @@ export function ProjectsSuspendable(): React.ReactElement {
       },
       {
         Header: "Creation date",
+        id: "creationDate",
         accessor: (p: ProjectDto) => (
           <Tooltip text={formatAsDateTime(p.item.creationDate)}>
             {formatAsDate(p.item.creationDate)}
@@ -43,6 +48,7 @@ export function ProjectsSuspendable(): React.ReactElement {
       },
       {
         Header: "Last update",
+        id: "lastUpdate",
         accessor: (p: ProjectDto) => (
           <Tooltip text={formatAsDateTime(p.item.lastUpdate)}>
             {formatAsDate(p.item.lastUpdate)}
@@ -51,6 +57,7 @@ export function ProjectsSuspendable(): React.ReactElement {
       },
       {
         id: "actions",
+        disableSortBy: true,
         accessor: (p: ProjectDto) => (
           <ContextActions
             actions={[
@@ -71,7 +78,7 @@ export function ProjectsSuspendable(): React.ReactElement {
     ],
     [setModalDialog]
   );
-  return projects.length === 0 ? (
+  return projectsChunk.length === 0 ? (
     <EmptyPlaceholder
       title="No projects created yet"
       description="All created projects will be displayed here"
@@ -82,6 +89,6 @@ export function ProjectsSuspendable(): React.ReactElement {
       }
     />
   ) : (
-    <Table data={projects} columns={projectColumns} />
+    <Table dataOrQuery={projectsQuery} columns={projectColumns} />
   );
 }

--- a/frontend/src/pages/library/Targets.tsx
+++ b/frontend/src/pages/library/Targets.tsx
@@ -6,7 +6,7 @@ import { useRecoilValue } from "recoil";
 import { Column } from "react-table";
 import React from "react";
 import { Link } from "react-router-dom";
-import { targetsQuery } from "../../store/selectors";
+import { defaultBatchQuery, targetsQuery } from "../../store/selectors";
 import { TargetDto } from "../../api/types";
 import { formatAsDate, formatAsDateTime } from "../../utils/utils";
 import { EmptyPlaceholder } from "../../components/EmptyPlaceholder/EmptyPlaceholder";
@@ -17,7 +17,7 @@ import { Tooltip } from "../../components/Tooltip/Tooltip";
 
 export function TargetsSuspendable(): React.ReactElement {
   // TODO request here only 1st page to check projects emptiness
-  const targetsChunk = useRecoilValue(targetsQuery({}));
+  const targetsChunk = useRecoilValue(defaultBatchQuery(targetsQuery));
   const targetColumns: Column<TargetDto>[] = React.useMemo(
     () => [
       {
@@ -53,6 +53,6 @@ export function TargetsSuspendable(): React.ReactElement {
       }
     />
   ) : (
-    <Table dataOrQuery={targetsQuery} columns={targetColumns} />
+    <Table dataOrQuery={targetsQuery} columns={targetColumns} defaultSortedColumn="name" />
   );
 }

--- a/frontend/src/pages/library/Targets.tsx
+++ b/frontend/src/pages/library/Targets.tsx
@@ -16,19 +16,23 @@ import { ExtraFormatter } from "../../components/ExtraFormatter";
 import { Tooltip } from "../../components/Tooltip/Tooltip";
 
 export function TargetsSuspendable(): React.ReactElement {
-  const targets = useRecoilValue(targetsQuery);
+  // TODO request here only 1st page to check projects emptiness
+  const targetsChunk = useRecoilValue(targetsQuery({}));
   const targetColumns: Column<TargetDto>[] = React.useMemo(
     () => [
       {
         Header: "Target",
+        id: "name",
         accessor: (t: TargetDto) => t.item.name,
       },
       {
         Header: "Projects",
+        disableSortBy: true,
         accessor: (t: TargetDto) => <ExtraFormatter items={t.item.projects} />,
       },
       {
         Header: "Addition date",
+        id: "additionDate",
         accessor: (t: TargetDto) => (
           <Tooltip text={formatAsDateTime(t.item.additionDate)}>
             {formatAsDate(t.item.additionDate)}
@@ -38,7 +42,7 @@ export function TargetsSuspendable(): React.ReactElement {
     ],
     []
   );
-  return targets.length === 0 ? (
+  return targetsChunk.length === 0 ? (
     <EmptyPlaceholder
       title="No targets added yet"
       description="To add targets add new experiments"
@@ -49,6 +53,6 @@ export function TargetsSuspendable(): React.ReactElement {
       }
     />
   ) : (
-    <Table data={targets} columns={targetColumns} />
+    <Table dataOrQuery={targetsQuery} columns={targetColumns} />
   );
 }

--- a/frontend/src/pages/upload/UploadPage.tsx
+++ b/frontend/src/pages/upload/UploadPage.tsx
@@ -28,15 +28,16 @@ import {
   useCompoundsRefresher,
   useFilteredExperimentsRefresher,
   useMethodologiesRefresher,
-  useProjectRefresher,
+  useProjectsRefresher,
   useTargetsRefresher,
 } from "../../store/updaters";
 
 export const UploadPage: FunctionComponent = (): ReactElement => {
-  const projectsLoadable = useRecoilValueLoadable(projectsQuery);
-  const methodologiesLoadable = useRecoilValueLoadable(methodologiesQuery);
+  // TODO make it async
+  const projectsLoadable = useRecoilValueLoadable(projectsQuery({}));
+  const methodologiesLoadable = useRecoilValueLoadable(methodologiesQuery({}));
   const [excelFile, setExcelFile] = useRecoilState(excelFileAtom);
-  const projectsRefresher = useProjectRefresher();
+  const projectsRefresher = useProjectsRefresher();
   const targetsRefresher = useTargetsRefresher();
   const compoundsRefresher = useCompoundsRefresher();
   const filteredExperimentsRefresher = useFilteredExperimentsRefresher();

--- a/frontend/src/store/selectors.ts
+++ b/frontend/src/store/selectors.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Derived state should be placed here
-import { selector, selectorFamily, waitForAll } from "recoil";
+import { RecoilValueReadOnly, selector, selectorFamily, waitForAll } from "recoil";
 import {
   colorsCounterAtom,
   compoundIdSelectedAtom,
@@ -63,6 +63,16 @@ export const targetsQuery = selectorFamily({
     return Api.fetchTargets(sortingParams);
   },
 });
+
+export function defaultBatchQuery<T>(
+  sel: (params: SortParamsApi) => RecoilValueReadOnly<T>,
+  params?: SortParamsApi
+): RecoilValueReadOnly<T> {
+  if (params) {
+    return sel(params);
+  }
+  return sel({ sortby: "name", desc: false });
+}
 
 // Dashboard page
 export const projectSelectedQuery = selector<Maybe<ProjectDto>>({

--- a/frontend/src/store/selectors.ts
+++ b/frontend/src/store/selectors.ts
@@ -27,37 +27,40 @@ import {
   ExperimentsWithMean,
   SubExperimentWithMeasurements,
 } from "./types";
+import { SortParamsApi } from "../api/EdnaApi";
 
 // Library page
-export const projectsQuery = selector({
+export const projectsQuery = selectorFamily({
   key: "projectsQuery",
-  get: async ({ get }) => {
-    get(projectsRequestIdAtom); // Add request ID as a dependency
-    return Api.fetchProjects();
+  get: (sortingParams: SortParamsApi) => async ({ get }) => {
+    // Add request ID as a dependency, to enforce refresh of all sorting params
+    get(projectsRequestIdAtom);
+    return Api.fetchProjects(sortingParams);
   },
 });
 
-export const methodologiesQuery = selector({
+export const methodologiesQuery = selectorFamily({
   key: "methodologiesQuery",
-  get: async ({ get }) => {
-    get(methodologiesRequestIdAtom); // Add request ID as a dependency
-    return Api.fetchMethodologies();
+  get: (sortingParams: SortParamsApi) => async ({ get }) => {
+    // Add request ID as a dependency, to enforce refresh of all sorting params
+    get(methodologiesRequestIdAtom);
+    return Api.fetchMethodologies(sortingParams);
   },
 });
 
-export const compoundsQuery = selector({
+export const compoundsQuery = selectorFamily({
   key: "compoundsQuery",
-  get: async ({ get }) => {
+  get: (sortingParams: SortParamsApi) => async ({ get }) => {
     get(compoundsReqIdAtom); // Add request ID as a dependency
-    return Api.fetchCompounds();
+    return Api.fetchCompounds(sortingParams);
   },
 });
 
-export const targetsQuery = selector({
+export const targetsQuery = selectorFamily({
   key: "targetsQuery",
-  get: async ({ get }) => {
+  get: (sortingParams: SortParamsApi) => async ({ get }) => {
     get(targetsRequestIdAtom); // Add request ID as a dependency
-    return Api.fetchTargets();
+    return Api.fetchTargets(sortingParams);
   },
 });
 
@@ -67,7 +70,7 @@ export const projectSelectedQuery = selector<Maybe<ProjectDto>>({
   get: ({ get }) => {
     const projectId = get(projectSelectedIdAtom);
     if (!isDefined(projectId)) return undefined;
-    const projects = get(projectsQuery);
+    const projects = get(projectsQuery({}));
     return projects.find(p => p.id === projectId);
   },
 });
@@ -76,8 +79,10 @@ export const compoundSelectedQuery = selector<Maybe<CompoundDto>>({
   key: "DashboardCompoundSelected",
   get: ({ get }) => {
     const compoundId = get(compoundIdSelectedAtom);
-    if (!isDefined(compoundId)) return undefined;
-    const compounds = get(compoundsQuery);
+    if (!isDefined(compoundId)) {
+      return undefined;
+    }
+    const compounds = get(compoundsQuery({}));
     return compounds.find(p => p.id === compoundId);
   },
 });
@@ -86,8 +91,10 @@ export const targetSelectedQuery = selector<Maybe<TargetDto>>({
   key: "DashboardTargetSelected",
   get: ({ get }) => {
     const targetId = get(targetIdSelectedAtom);
-    if (!isDefined(targetId)) return undefined;
-    const targets = get(targetsQuery);
+    if (!isDefined(targetId)) {
+      return undefined;
+    }
+    const targets = get(targetsQuery({}));
     return targets.find(p => p.id === targetId);
   },
 });
@@ -108,31 +115,31 @@ export const subExperimentsWithMeasurementsQuery = selectorFamily<
   },
 });
 
-const filteredExperimentsDtoQuery = selector<ExperimentsWithMeanDto>({
+export const filteredExperimentsDtoQuery = selectorFamily<ExperimentsWithMeanDto, SortParamsApi>({
   key: "FilteredExperimentsDtoQuery",
-  get: async ({ get }) => {
+  get: (sortingParams: SortParamsApi) => async ({ get }) => {
     get(filteredExperimentsReqIdAtom);
     const projectId = get(projectSelectedIdAtom);
     const compoundId = get(compoundIdSelectedAtom);
     const targetId = get(targetIdSelectedAtom);
-    return Api.fetchExperiments(projectId, compoundId, targetId);
+    return Api.fetchExperiments(projectId, compoundId, targetId, sortingParams);
   },
 });
 
-export const filteredExperimentsQuery = selector<ExperimentsWithMean>({
+export const filteredExperimentsQuery = selectorFamily<ExperimentsWithMean, SortParamsApi>({
   key: "DashboardExperiments",
-  get: ({ get }) => {
-    const { experiments, meanIC50 } = get(filteredExperimentsDtoQuery);
+  get: (sortingParams: SortParamsApi) => ({ get }) => {
+    const { experiments, meanIC50 } = get(filteredExperimentsDtoQuery(sortingParams));
 
     // TODO fix this quadratic time
     function findName(elements: { id: number; item: { name: string } }[], id: number) {
       return elements.find(x => x.id === id)?.item.name;
     }
 
-    const projects = get(projectsQuery);
-    const compounds = get(compoundsQuery);
-    const targets = get(targetsQuery);
-    const methodologies = get(methodologiesQuery);
+    const projects = get(projectsQuery({}));
+    const compounds = get(compoundsQuery({}));
+    const targets = get(targetsQuery({}));
+    const methodologies = get(methodologiesQuery({}));
 
     const exps: Experiment[] = experiments
       .map(e => {
@@ -173,18 +180,7 @@ export const selectedSubExperimentsQuery = selector<SubExperimentWithMeasurement
   },
 });
 
-export const selectedExperimentsQuery = selector<Set<number>>({
-  key: "SelectedExperiments",
-  get: ({ get }) => {
-    const filtered = get(filteredExperimentsQuery).experiments;
-    const subs = get(selectedSubExperimentsIdsAtom);
-    return new Set(
-      filtered.filter(e => isDefined(e.subExperiments.find(x => subs.has(x)))).map(x => x.id)
-    );
-  },
-});
-
-export const minAmountColor = selector<string>({
+export const minAmountColorQuery = selector<string>({
   key: "MinAmountColor",
   get: ({ get }) => {
     const amounts = chartColors.map(col => get(colorsCounterAtom(col)));

--- a/frontend/src/typings/react-table-config.d.ts
+++ b/frontend/src/typings/react-table-config.d.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { UsePaginationOptions, UseSortByOptions } from "react-table";
+
+// Taken from here: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-table
+declare module "react-table" {
+  export interface TableOptions<D extends Record<string, unknown>>
+    extends UsePaginationOptions<D>,
+      UseSortByOptions<D> {}
+
+  export type Hooks<D extends Record<string, unknown> = Record<string, unknown>> = UseSortByHooks<
+    D
+  >;
+
+  export interface TableInstance<D extends Record<string, unknown> = Record<string, unknown>>
+    extends UsePaginationInstanceProps<D>,
+      UseSortByInstanceProps<D> {}
+
+  export interface TableState<D extends Record<string, unknown> = Record<string, unknown>>
+    extends UsePaginationState<D>,
+      UseSortByState<D> {}
+
+  export type ColumnInterface<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > = UseSortByColumnOptions<D>;
+
+  export interface ColumnInstance<D extends Record<string, unknown> = Record<string, unknown>>
+    extends UseResizeColumnsColumnProps<D>,
+      UseSortByColumnProps<D> {}
+}


### PR DESCRIPTION
Problem: we would like to be capable of sorting tables
by single column.

Solution: add machinery for react-table to re-request data for every sorting request.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-46

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
