### PR TITLE
[EDNA-77] Add pagination+sorting for Library and Dashboard getters

### DIFF
--- a/backend/cabal.project
+++ b/backend/cabal.project
@@ -10,6 +10,7 @@ source-repository-package
     location: https://github.com/serokell/servant-util
     tag: 3dff2de34cce90c4d1dab68e03d30f8939fd52ca
     subdir: servant-util
+            servant-util-beam-pg
 
 allow-older: *
 allow-newer: *

--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -45,6 +45,7 @@ library
       Edna.DB.Initialisation
       Edna.DB.Integration
       Edna.DB.Schema
+      Edna.DB.Util
       Edna.Dashboard.DB.Query
       Edna.Dashboard.DB.Schema
       Edna.Dashboard.Error

--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -107,6 +107,7 @@ library
     servant-swagger-ui-core,
     servant-swagger-ui,
     servant-util,
+    servant-util-beam-pg,
     split,
     swagger2,
     text,
@@ -194,5 +195,6 @@ test-suite edna-test
     , QuickCheck
     , rio
     , servant-swagger
+    , servant-util
     , unordered-containers
     , xlsx

--- a/backend/src/Edna/Analysis/FourPL.hs
+++ b/backend/src/Edna/Analysis/FourPL.hs
@@ -42,7 +42,7 @@ data Params4PL = Params4PL
   , p4plB :: Double
   , p4plC :: Double
   , p4plD :: Double
-  } deriving stock (Generic, Show, Eq)
+  } deriving stock (Generic, Show, Eq, Ord)
 
 type Params4PLTuple = (Double, Double, Double, Double)
 

--- a/backend/src/Edna/DB/Util.hs
+++ b/backend/src/Edna/DB/Util.hs
@@ -1,0 +1,54 @@
+-- SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+-- | Utility module to write functions that deal with DB.
+
+module Edna.DB.Util
+  ( groupAndPaginate
+  ) where
+
+import Universum
+
+import qualified Data.HashMap.Strict as HM
+import qualified Data.HashSet as HashSet
+import qualified Data.Set as Set
+
+import Lens.Micro (at)
+import Servant.Util (PaginationSpec(..))
+import Servant.Util.Dummy.Pagination (paginate)
+
+import Edna.DB.Schema ()
+
+-- | This function is helpful for queries where we use left join and get
+-- pairs of items. The first item is the main and legendary one, it is requested.
+-- We call it @boka@. Each @boka@ has a list of grandchildren, we call them
+-- @joka@. There can be multiple items with the same @boka@ values. @boka@
+-- has a primary key that we use for identification.
+-- There are 3 goals here:
+--
+-- 1. Group items with the same @boka@ value.
+-- 2. Preserving sorting of items.
+-- 3. Carefully apply pagination, it should be applied __after__ grouping.
+groupAndPaginate :: forall boka joka pk.
+  (Hashable pk, Eq pk, Ord joka) =>
+  Maybe PaginationSpec -> (boka -> pk) ->
+  [(boka, Maybe joka)] -> [(boka, [joka])]
+groupAndPaginate mPagination toPrimaryKey items =
+  maybe id paginate mPagination $ snd $ foldr (step . fst) (mempty, []) items
+  where
+    step :: boka -> (HashSet pk, [(boka, [joka])]) -> (HashSet pk, [(boka, [joka])])
+    step boka acc@(visited, res)
+      | HashSet.member pk visited = acc
+      | otherwise =
+        ( HashSet.insert pk visited
+        , (boka, maybe [] toList $ bokaToJokas ^. at pk) : res
+        )
+      where
+        pk = toPrimaryKey boka
+
+    bokaToJokas :: HashMap pk (Set joka)
+    bokaToJokas = foldl' innerStep mempty items
+      where
+        innerStep acc (boka, mJoka) =
+          maybe acc (\joka -> HM.insertWith Set.union (toPrimaryKey boka) (one joka) acc) mJoka

--- a/backend/src/Edna/Dashboard/Service.hs
+++ b/backend/src/Edna/Dashboard/Service.hs
@@ -27,6 +27,7 @@ import Database.Beam.Backend.SQL.BeamExtensions (unSerial)
 import Database.Beam.Postgres (PgJSON(..))
 import Fmt (fmt, (+|), (|+))
 import Servant.API (NoContent(..))
+import Servant.Util (PaginationSpec)
 
 import qualified Edna.Dashboard.DB.Query as Q
 import qualified Edna.Upload.DB.Query as UQ
@@ -36,8 +37,8 @@ import Edna.DB.Integration (transact)
 import Edna.Dashboard.DB.Schema (MeasurementT(..), SubExperimentRec, SubExperimentT(..))
 import Edna.Dashboard.Error (DashboardError(..))
 import Edna.Dashboard.Web.Types
-  (ExperimentFileBlob(..), ExperimentMetadata(..), ExperimentResp(..), ExperimentsResp(..),
-  MeasurementResp(..), NewSubExperimentReq(..), SubExperimentResp(..))
+  (ExperimentFileBlob(..), ExperimentMetadata(..), ExperimentResp(..), ExperimentSortingSpec,
+  ExperimentsResp(..), MeasurementResp(..), NewSubExperimentReq(..), SubExperimentResp(..))
 import Edna.ExperimentReader.Types (FileMetadata(..))
 import Edna.Logging (logMessage)
 import Edna.Setup (Edna)
@@ -133,9 +134,9 @@ analyseNewSubExperiment subExpId NewSubExperimentReq {..} = do
 -- compound ID and target ID. If filters by compound and target are specified,
 -- also compute average IC50 for them.
 getExperiments :: Maybe ProjectId -> Maybe CompoundId -> Maybe TargetId ->
-  Edna ExperimentsResp
-getExperiments mProj mComp mTarget = do
-  pairs <- Q.getExperiments mProj mComp mTarget
+  ExperimentSortingSpec -> PaginationSpec -> Edna ExperimentsResp
+getExperiments mProj mComp mTarget sorting pagination = do
+  pairs <- Q.getExperiments mProj mComp mTarget sorting pagination
   meanIC50 <- case (mComp, mTarget) of
     (Just _, Just _) -> computeMeanIC50 (map snd pairs)
     _ -> pure Nothing

--- a/backend/src/Edna/Dashboard/Web/API.hs
+++ b/backend/src/Edna/Dashboard/Web/API.hs
@@ -18,6 +18,7 @@ import Servant.API
   Summary, (:>))
 import Servant.API.Generic (AsApi, ToServant, (:-))
 import Servant.Server.Generic (AsServerT, genericServerT)
+import Servant.Util (PaginationParams, SortingParamsOf)
 
 import Edna.Analysis.FourPL (AnalysisResult)
 import Edna.Dashboard.Service
@@ -27,9 +28,7 @@ import Edna.Dashboard.Service
 import Edna.Dashboard.Web.Types
 import Edna.Setup (Edna)
 import Edna.Util (CompoundId, ExperimentId, IdType(..), ProjectId, SubExperimentId, TargetId)
-import Edna.Web.Types (StubSortBy, WithId)
-
--- TODO: pagination and sorting are just stubs for now.
+import Edna.Web.Types (WithId)
 
 -- | Endpoints related to projects.
 data DashboardEndpoints route = DashboardEndpoints
@@ -93,9 +92,8 @@ data DashboardEndpoints route = DashboardEndpoints
       :> QueryParam "compoundId" CompoundId
       :> QueryParam "targetId" TargetId
 
-      :> QueryParam "page" Word
-      :> QueryParam "size" Word
-      :> QueryParam "sortby" StubSortBy
+      :> SortingParamsOf ExperimentResp
+      :> PaginationParams
       :> Get '[JSON] ExperimentsResp
 
   , -- | Get experiment's metadata by ID
@@ -141,7 +139,7 @@ dashboardEndpoints = genericServerT DashboardEndpoints
   , deDeleteSubExp = deleteSubExperiment
   , deNewSubExp = newSubExperiment
   , deAnalyseNewSubExp = fmap snd ... analyseNewSubExperiment
-  , deGetExperiments = \p c t _ _ _ -> getExperiments p c t
+  , deGetExperiments = getExperiments
   , deGetExperimentMetadata = getExperimentMetadata
   , deGetExperimentFile = \i -> getExperimentFile i <&>
       \(name, blob) -> addHeader ("attachment;filename=" <> name) blob

--- a/backend/src/Edna/Dashboard/Web/Types.hs
+++ b/backend/src/Edna/Dashboard/Web/Types.hs
@@ -8,6 +8,7 @@ module Edna.Dashboard.Web.Types
   ( NewSubExperimentReq (..)
   , ExperimentsResp (..)
   , ExperimentResp (..)
+  , ExperimentSortingSpec
   , SubExperimentResp (..)
   , MeasurementResp (..)
   , ExperimentMetadata (..)
@@ -18,11 +19,12 @@ import Universum
 
 import Data.Aeson.TH (deriveJSON, deriveToJSON)
 import Data.Swagger (NamedSchema(..), ToSchema(..), binarySchema)
-import Data.Time (UTCTime)
+import Data.Time (LocalTime, UTCTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
 import Fmt (Buildable(..), Builder, genericF, tupleF, (+|), (|+))
 import Servant.API (Header, Headers, getHeaders, getResponse)
 import Servant.API.ContentTypes (MimeRender, OctetStream)
+import Servant.Util (SortingParamTypesOf, SortingSpec, type (?:))
 import Servant.Util.Combinators.Logging (ForResponseLog(..), buildForResponse, buildListForResponse)
 
 import Edna.Analysis.FourPL (AnalysisResult)
@@ -95,6 +97,15 @@ instance Buildable ExperimentResp where
 
 instance Buildable (ForResponseLog ExperimentResp) where
   build = buildForResponse
+
+-- TODO [EDNA-89] Add more fields
+type instance SortingParamTypesOf ExperimentResp =
+  '["uploadDate" ?: LocalTime
+  -- ↑ LocalTime is stored in DB, the difference between LocalTime and UTCTime
+  -- does not matter for sorting.
+  ]
+
+type ExperimentSortingSpec = SortingSpec (SortingParamTypesOf ExperimentResp)
 
 -- | SubExperiment as response from the server.
 data SubExperimentResp = SubExperimentResp

--- a/backend/src/Edna/Library/Web/API.hs
+++ b/backend/src/Edna/Library/Web/API.hs
@@ -25,9 +25,10 @@ module Edna.Library.Web.API
 import Universum
 
 import Servant (ReqBody)
-import Servant.API (Capture, Delete, Get, JSON, NoContent, Post, Put, QueryParam, Summary, (:>))
+import Servant.API (Capture, Delete, Get, JSON, NoContent, Post, Put, Summary, (:>))
 import Servant.API.Generic (AsApi, ToServant, (:-))
 import Servant.Server.Generic (AsServerT, genericServerT)
+import Servant.Util (PaginationParams, SortingParamsOf)
 
 import Edna.Library.Service
   (addMethodology, addProject, deleteMethodology, editChemSoft, editMde, getCompound, getCompounds,
@@ -37,11 +38,7 @@ import Edna.Library.Web.Types
   (CompoundResp, MethodologyReq, MethodologyResp, ProjectReq, ProjectResp, TargetResp)
 import Edna.Setup (Edna)
 import Edna.Util (IdType(..), MethodologyId, SqlId(..))
-import Edna.Web.Types (StubSortBy, URI, WithId)
-
--- TODO: pagination and sorting are just stubs for now (everywhere).
--- Most likely we will use @servant-util@ to implement them,
--- but let's do it later.
+import Edna.Web.Types (URI, WithId)
 
 -- | Endpoints related to projects.
 data ProjectEndpoints route = ProjectEndpoints
@@ -64,9 +61,8 @@ data ProjectEndpoints route = ProjectEndpoints
     peGetProjects :: route
       :- "projects"
       :> Summary "Get known projects"
-      :> QueryParam "page" Word
-      :> QueryParam "size" Word
-      :> QueryParam "sortby" StubSortBy
+      :> SortingParamsOf ProjectResp
+      :> PaginationParams
       :> Get '[JSON] [WithId 'ProjectId ProjectResp]
 
   , -- | Get project data by ID
@@ -115,9 +111,8 @@ data MethodologyEndpoints route = MethodologyEndpoints
     meGetMethodologies :: route
       :- "methodologies"
       :> Summary "Get known methodologies"
-      :> QueryParam "page" Word
-      :> QueryParam "size" Word
-      :> QueryParam "sortby" StubSortBy
+      :> SortingParamsOf MethodologyResp
+      :> PaginationParams
       :> Get '[JSON] [WithId 'MethodologyId MethodologyResp]
 
   , -- | Get methodology data by ID
@@ -145,9 +140,8 @@ data TargetEndpoints route = TargetEndpoints
     teGetTargets :: route
       :- "targets"
       :> Summary "Get known targets"
-      :> QueryParam "page" Word
-      :> QueryParam "size" Word
-      :> QueryParam "sortby" StubSortBy
+      :> SortingParamsOf TargetResp
+      :> PaginationParams
       :> Get '[JSON] [WithId 'TargetId TargetResp]
 
   , -- | Get target data by ID
@@ -190,9 +184,8 @@ data CompoundEndpoints route = CompoundEndpoints
     ceGetCompounds :: route
       :- "compounds"
       :> Summary "Get known compounds"
-      :> QueryParam "page" Word
-      :> QueryParam "size" Word
-      :> QueryParam "sortby" StubSortBy
+      :> SortingParamsOf CompoundResp
+      :> PaginationParams
       :> Get '[JSON] [WithId 'CompoundId CompoundResp]
 
   , -- | Get compound data by ID

--- a/backend/src/Edna/Library/Web/Types.hs
+++ b/backend/src/Edna/Library/Web/Types.hs
@@ -6,21 +6,26 @@
 
 module Edna.Library.Web.Types
   ( TargetResp (..)
+  , TargetSortingSpec
   , CompoundResp (..)
+  , CompoundSortingSpec
   , MethodologyReq (..)
   , MethodologyResp (..)
+  , MethodologySortingSpec
   , ProjectReq (..)
   , ProjectResp (..)
+  , ProjectSortingSpec
   ) where
 
 import Universum
 
 import Data.Aeson.TH (deriveJSON)
 import Data.Swagger (ToSchema(..))
-import Data.Time (UTCTime)
+import Data.Time (LocalTime, UTCTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
 import Fmt (Buildable(..), genericF, (+|), (|+))
 import Network.URI.JSON ()
+import Servant.Util (SortingParamTypesOf, SortingSpec, type (?:))
 import Servant.Util.Combinators.Logging (ForResponseLog(..), buildForResponse)
 
 import Edna.Util (ednaAesonWebOptions, gDeclareNamedSchema)
@@ -65,6 +70,16 @@ instance ToSchema ProjectReq where
 instance ToSchema ProjectResp where
   declareNamedSchema = gDeclareNamedSchema
 
+type instance SortingParamTypesOf ProjectResp =
+  '["name" ?: Text
+  -- LocalTime is stored in DB, the difference between LocalTime and UTCTime
+  -- does not matter for sorting.
+  , "creationDate" ?: LocalTime
+  , "lastUpdate" ?: LocalTime
+  ]
+
+type ProjectSortingSpec = SortingSpec (SortingParamTypesOf ProjectResp)
+
 -- | Test methodology as submitted by end users.
 data MethodologyReq = MethodologyReq
   { mrqName :: Text
@@ -104,6 +119,10 @@ deriveJSON ednaAesonWebOptions ''MethodologyResp
 instance ToSchema URI => ToSchema MethodologyResp where
   declareNamedSchema = gDeclareNamedSchema
 
+type instance SortingParamTypesOf MethodologyResp = '["name" ?: Text]
+
+type MethodologySortingSpec = SortingSpec (SortingParamTypesOf MethodologyResp)
+
 -- | Targets are not submitted directly by users, so for now
 -- there is only one representation for frontend.
 data TargetResp = TargetResp
@@ -127,6 +146,11 @@ deriveJSON ednaAesonWebOptions ''TargetResp
 
 instance ToSchema TargetResp where
   declareNamedSchema = gDeclareNamedSchema
+
+type instance SortingParamTypesOf TargetResp =
+  '["name" ?: Text, "additionDate" ?: LocalTime]
+
+type TargetSortingSpec = SortingSpec (SortingParamTypesOf TargetResp)
 
 -- | Compounds are not submitted directly by users, so for now
 -- there is only one representation for frontend.
@@ -152,3 +176,8 @@ deriveJSON ednaAesonWebOptions ''CompoundResp
 
 instance ToSchema URI => ToSchema CompoundResp where
   declareNamedSchema = gDeclareNamedSchema
+
+type instance SortingParamTypesOf CompoundResp =
+  '["name" ?: Text, "additionDate" ?: LocalTime]
+
+type CompoundSortingSpec = SortingSpec (SortingParamTypesOf CompoundResp)

--- a/backend/src/Edna/Web/Types.hs
+++ b/backend/src/Edna/Web/Types.hs
@@ -2,13 +2,13 @@
 --
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 
--- | Bridge types used to communicate between the server app and frontend.
+-- | Legacy module that currently defines only 'WithId' type and should probably
+-- be changed somehow.
 
 {-# LANGUAGE OverloadedLists #-}
 
 module Edna.Web.Types
   ( WithId (..)
-  , StubSortBy (..)
 
   -- * Re-exported for convenience
   , URI (..)
@@ -17,15 +17,12 @@ module Edna.Web.Types
 import Universum
 
 import Data.Aeson.TH (deriveToJSON)
-import Data.Swagger
-  (SwaggerType(..), ToParamSchema(..), ToSchema(..), declareSchemaRef, enum_, properties, required,
-  type_)
+import Data.Swagger (SwaggerType(..), ToSchema(..), declareSchemaRef, properties, required, type_)
 import Data.Swagger.Internal.Schema (unnamed)
 import Fmt (Buildable(..))
 import Lens.Micro ((?~))
 import Network.URI (URI(..))
 import Network.URI.JSON ()
-import Servant (FromHttpApiData(..))
 import Servant.Util.Combinators.Logging (ForResponseLog(..), buildForResponse, buildListForResponse)
 
 import Edna.Util (SqlId(..), ednaAesonWebOptions)
@@ -49,21 +46,6 @@ instance Buildable t => Buildable (ForResponseLog (WithId k t)) where
 instance Buildable t => Buildable (ForResponseLog [WithId k t]) where
   build = buildListForResponse (take 5)
 
--- | A stub to specify the sorting order, most likely will be replaced with
--- @servant-util@.
-data StubSortBy =
-    SortByName
-  | SortBySomething
-
-instance Buildable StubSortBy where
-  build _ = "STUB"
-
-instance FromHttpApiData StubSortBy where
-  parseQueryParam = \case
-    "name" -> pure SortByName
-    "something" -> pure SortBySomething
-    x -> Left $ "unknown sorting order: " <> x
-
 ----------------
 -- JSON
 ----------------
@@ -85,8 +67,3 @@ instance ToSchema t => ToSchema (WithId k t) where
           , ("item", itemSchema)
           ]
       & required .~ [ "id", "item" ]
-
-instance ToParamSchema StubSortBy where
-  toParamSchema _ = mempty
-     & type_ ?~ SwaggerString
-     & enum_ ?~ [ "name", "something" ]

--- a/backend/stack.yaml
+++ b/backend/stack.yaml
@@ -40,6 +40,7 @@ extra-deps:
   commit: 3dff2de34cce90c4d1dab68e03d30f8939fd52ca # not master
   subdirs:
     - servant-util
+    - servant-util-beam-pg
 
 # beam-core currently doesn't support aeson from the resolver we are using
 allow-newer: true

--- a/backend/test/Test/Gen.hs
+++ b/backend/test/Test/Gen.hs
@@ -15,7 +15,6 @@ module Test.Gen
     -- * Hedgehog
     genSqlId
   , genWithId
-  , genStubSortBy
   , genNameAndId
   , genParams4PL
   , genFileSummaryItem
@@ -80,9 +79,6 @@ genSqlId = SqlId <$> Gen.integral (Range.constant 0 100)
 
 genWithId :: MonadGen m => m t -> m (WithId k t)
 genWithId genT = WithId <$> genSqlId <*> genT
-
-genStubSortBy :: MonadGen m => m StubSortBy
-genStubSortBy = Gen.element [SortByName, SortBySomething]
 
 genName :: MonadGen m => m Text
 genName = Gen.text (Range.linear 1 30) Gen.unicode
@@ -281,9 +277,6 @@ deriving newtype instance Arbitrary (SqlId t)
 
 instance Arbitrary t => Arbitrary (WithId k t) where
   arbitrary = hedgehog $ genWithId HQC.arbitrary
-
-instance Arbitrary StubSortBy where
-  arbitrary = hedgehog genStubSortBy
 
 instance Arbitrary URI where
   arbitrary = hedgehog genURI

--- a/backend/test/Test/UploadSpec.hs
+++ b/backend/test/Test/UploadSpec.hs
@@ -15,6 +15,7 @@ import qualified Data.Set as Set
 
 import Data.List ((!!))
 import RIO (runRIO)
+import Servant.Util (fullContent, noSorting)
 import Test.Hspec (Spec, beforeAllWith, describe, it, shouldBe, shouldThrow)
 
 import qualified Edna.Dashboard.Service as Dashboard
@@ -63,8 +64,8 @@ spec = withContext $ startWithInitial $ do
         "blob" sampleFile
       summary2 <- uploadFile' (SqlId 2) (SqlId 2) "file description 2" "file name 2"
         "blob2" sampleFile2
-      targets <- Library.getTargets Nothing Nothing Nothing
-      compounds <- Library.getCompounds Nothing Nothing Nothing
+      targets <- Library.getTargets noSorting fullContent
+      compounds <- Library.getCompounds noSorting fullContent
       experiments <- Dashboard.getExperiments Nothing Nothing Nothing
       liftIO $ do
         summary `shouldBe` sortFileSummary sampleFileSummary'

--- a/backend/test/Test/UploadSpec.hs
+++ b/backend/test/Test/UploadSpec.hs
@@ -67,6 +67,7 @@ spec = withContext $ startWithInitial $ do
       targets <- Library.getTargets noSorting fullContent
       compounds <- Library.getCompounds noSorting fullContent
       experiments <- Dashboard.getExperiments Nothing Nothing Nothing
+        noSorting fullContent
       liftIO $ do
         summary `shouldBe` sortFileSummary sampleFileSummary'
         summary2 `shouldBe` sortFileSummary sampleFileSummary2
@@ -77,6 +78,7 @@ spec = withContext $ startWithInitial $ do
       projId <- wiId <$> Library.addProject (ProjectReq "autoOutlierFile" Nothing)
       void $ uploadFileTest projId (SqlId 1) autoOutlierFile
       ExperimentsResp {..} <- Dashboard.getExperiments (Just projId) Nothing Nothing
+        noSorting fullContent
       -- @autoOutlierFile@ has only 1 experiment and we are adding it into a
       -- completely new project. So we expect one experiment in the result.
       let [WithId _ ExperimentResp {..}] = erExperiments


### PR DESCRIPTION
## Description

Problem: the number of projects, compounds and other entities stored
in Edna may be quite big sometimes. In this case we don't want to
transfer all entities to frontend at once, it may take quite a lot of
time to load a page.
Also it should be possible to sort entities in tables. We can do it on
frontend if we return all items in one call, but if we return chunks of
data we need to know sorting order.

Solution: add pagination to library and dashboard getters that return lists.
We use `servant-util` and `servant-util-beam-pg` to achieve that.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-77

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
