### PR TITLE
[EDNA-120] Remove legacy /experiment endpoint

### DIFF
--- a/backend/src/Edna/Upload/Web/API.hs
+++ b/backend/src/Edna/Upload/Web/API.hs
@@ -8,29 +8,18 @@ module Edna.Upload.Web.API
   ( FileUploadEndpoints (..)
   , FileUploadAPI
   , fileUploadEndpoints
-
-  -- * Legacy
-  , ExperimentalMeasurement (..)
-  , uploadExperiment
   ) where
 
 import Universum
 
-import Data.Aeson.TH (deriveToJSON)
-import Data.Swagger (ToSchema(..))
-import Fmt (Buildable(..))
 import Servant.API (JSON, Post, Summary, (:>))
 import Servant.API.Generic (AsApi, ToServant, (:-))
 import Servant.Multipart (Mem, MultipartForm)
 import Servant.Server.Generic (AsServerT, genericServerT)
-import Servant.Util.Combinators.Logging (ForResponseLog(..))
 
-import Edna.ExperimentReader.Parser (parseExperimentXls)
-import Edna.ExperimentReader.Types (FileContents(..), Measurement(..), TargetMeasurements(..))
 import Edna.Setup (Edna)
 import Edna.Upload.Service (parseFile, uploadFile)
 import Edna.Upload.Web.Types (FileBS(..), FileSummary, FileUploadReq(..))
-import Edna.Util (ednaAesonWebOptions, gDeclareNamedSchema)
 
 -- | Endpoints necessary to implement file uploading.
 data FileUploadEndpoints route = FileUploadEndpoints
@@ -59,43 +48,3 @@ fileUploadEndpoints = genericServerT FileUploadEndpoints
   , fueUploadFile = \FileUploadReq{furFile = FileBS{..}, ..} ->
       uploadFile furProject furTestMethodology (fromMaybe "" furDescription) fbsName fbsFile
   }
-
-----------------
--- Legacy
-----------------
-
--- | Legacy type that will be removed soon.
-data ExperimentalMeasurement = ExperimentalMeasurement
-  { emCompoundId :: Text
-  , emTargetId :: Text
-  , emConcentration :: Double
-  , emSignal :: Double
-  , emOutlier :: Bool
-  } deriving stock (Generic, Show, Eq)
-
-instance Buildable (ForResponseLog [ExperimentalMeasurement]) where
-  build _ = "LEGACY ExperimentalMeasurement"
-
-deriveToJSON ednaAesonWebOptions ''ExperimentalMeasurement
-
-instance ToSchema ExperimentalMeasurement where
-  declareNamedSchema = gDeclareNamedSchema
-
--- Legacy function
-uploadExperiment :: FileBS -> Edna [ExperimentalMeasurement]
-uploadExperiment FileBS{..} = do
-  putStrLn $ "Excel file name " ++ show fbsName
-  fileContents <- either throwM pure (parseExperimentXls fbsFile)
-  let
-    flatten :: (Text, TargetMeasurements) -> [ExperimentalMeasurement]
-    flatten (targetName, TargetMeasurements targetMeasurements) =
-      flip concatMap (toPairs targetMeasurements) $ \(compoundName, measurements) ->
-      flip map measurements $ \Measurement {..} ->
-        ExperimentalMeasurement
-          { emCompoundId = compoundName
-          , emTargetId = targetName
-          , emConcentration = mConcentration
-          , emSignal = mSignal
-          , emOutlier = mIsOutlier
-          }
-  return $ concatMap flatten $ toPairs $ fcMeasurements fileContents

--- a/backend/src/Edna/Web/API.hs
+++ b/backend/src/Edna/Web/API.hs
@@ -13,26 +13,17 @@ module Edna.Web.API
 
 import Universum
 
-import Servant.API (GetNoContent, JSON, Post, Summary, (:<|>), (:>))
+import Servant.API (GetNoContent, Summary, (:<|>), (:>))
 import Servant.API.Generic (AsApi, ToServant, (:-))
-import Servant.Multipart (Mem, MultipartForm)
 
 import qualified Edna.Dashboard.Web.API as Dashboard
 import qualified Edna.Upload.Web.API as Upload
 
 import Edna.Library.Web.API (CompoundAPI, MethodologyAPI, ProjectAPI, TargetAPI)
-import Edna.Upload.Web.Types (FileBS)
 
 -- | API endpoints specification.
 data EdnaEndpoints route = EdnaEndpoints
-  { -- | Legacy: upload one experiment
-    eeUploadExperiment :: route
-      :- "experiment"
-      :> Summary "Upload an EXCEL file describing one experiment"
-      :> MultipartForm Mem FileBS
-      :> Post '[JSON] [Upload.ExperimentalMeasurement]
-
-  , eeFileUploadEndpoints :: route :- "file" :> Upload.FileUploadAPI
+  { eeFileUploadEndpoints :: route :- "file" :> Upload.FileUploadAPI
   , eeProjectEndpoints :: route :- ProjectAPI
   , eeMethodologyEndpoints :: route :- MethodologyAPI
   , eeCompoundEndpoints :: route :- CompoundAPI

--- a/backend/src/Edna/Web/Handlers.hs
+++ b/backend/src/Edna/Web/Handlers.hs
@@ -21,8 +21,7 @@ type EdnaHandlers m = ToServant EdnaEndpoints (AsServerT m)
 -- | Server handler implementation for Edna API.
 ednaHandlers :: EdnaHandlers Edna
 ednaHandlers = genericServerT EdnaEndpoints
-  { eeUploadExperiment = Upload.uploadExperiment
-  , eeFileUploadEndpoints = Upload.fileUploadEndpoints
+  { eeFileUploadEndpoints = Upload.fileUploadEndpoints
   , eeProjectEndpoints = Library.projectEndpoints
   , eeMethodologyEndpoints = Library.methodologyEndpoints
   , eeCompoundEndpoints = Library.compoundEndpoints

--- a/backend/test/Test/Gen.hs
+++ b/backend/test/Test/Gen.hs
@@ -65,7 +65,6 @@ import Edna.ExperimentReader.Types
 import Edna.Library.Web.Types
   (CompoundResp(..), MethodologyReq(..), MethodologyResp(..), ProjectReq(..), ProjectResp(..),
   TargetResp(..))
-import Edna.Upload.Web.API (ExperimentalMeasurement(..))
 import Edna.Upload.Web.Types (FileSummary(..), FileSummaryItem(..), NameAndId(..))
 import Edna.Util (SqlId(..), localToUTC)
 import Edna.Web.Types
@@ -276,18 +275,6 @@ genDoubleSmallPrec = divideBy128 <$> Gen.word64 (Range.constant 0 300)
 ----------------
 -- QuickCheck
 ----------------
-
--- This type is legacy and will likely be removed and replaced by something
--- else, so we are defining a dummy instance for now and now @hedgehog@
--- generator.
-instance Arbitrary ExperimentalMeasurement where
-  arbitrary = pure ExperimentalMeasurement
-    { emCompoundId = "aa"
-    , emTargetId = "qq"
-    , emConcentration = 0
-    , emSignal = 0
-    , emOutlier = True
-    }
 
 deriving newtype instance Arbitrary (SqlId t)
 


### PR DESCRIPTION
## Description

Problem: we have POST `/experiment` endpoint that we were using
to upload a new file, but it was a temporary solution and this
endpoint is not used anymore.

Solution: remove this endpoint.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-120

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
