### PR TITLE
Dependent dashboard selectors

### DIFF
--- a/frontend/src/components/Combobox.tsx
+++ b/frontend/src/components/Combobox.tsx
@@ -10,7 +10,7 @@ import { StylesConfig } from "react-select/src/styles";
 import { Maybe } from "../utils/utils";
 import { FormikCompatible } from "./FormField/FormField";
 
-export type SelectOption = { value: string; label: string };
+export type SelectOption = { value: string; label: string; isDisabled?: boolean };
 
 interface ComboboxProps<T> extends FormikCompatible<Maybe<T>> {
   optionsLoadable: Loadable<T[]>;
@@ -52,11 +52,19 @@ export default function Combobox<T>({
       optionsLoadable.state === "loading" ? { visibility: "hidden" } : { ...provided },
     option: (provided: any, state: any) => ({
       ...provided,
-      backgroundColor: state.isSelected ? "#bfe5d2" : state.isFocused ? "#edf8f2" : "white",
-      color: "#515151",
+      backgroundColor: state.isSelected
+        ? "#bfe5d2"
+        : state.isFocused
+        ? "#edf8f2"
+        : state.isDisabled
+        ? "#f0f0f0"
+        : "white",
+      color: state.isDisabled ? "rgba(25, 28, 28, 0.5)" : "#515151",
       "&:active": {
-        backgroundColor: "#bfe5d2",
+        backgroundColor: state.isDisabled ? "#f0f0f0" : "#bfe5d2",
       },
+      height: state.isDisabled ? "34px" : "40px",
+      padding: state.isDisabled ? "8px 22px" : "11px 22px",
     }),
     control: (provided: any, state: any) => ({
       ...provided,

--- a/frontend/src/components/Combobox.tsx
+++ b/frontend/src/components/Combobox.tsx
@@ -20,6 +20,7 @@ interface ComboboxProps<T> extends FormikCompatible<Maybe<T>> {
   isLoading?: boolean;
   styles?: StylesConfig<SelectOption, false, GroupTypeBase<SelectOption>>;
   isDisabled?: boolean;
+  optionsFilter?: (val: T[]) => T[] | undefined;
   [prop: string]: any;
 }
 
@@ -34,6 +35,7 @@ export default function Combobox<T>({
   styles,
   isLoading,
   isDisabled = false,
+  optionsFilter,
   ...props
 }: ComboboxProps<T>): React.ReactElement {
   const mergedStyles = {
@@ -91,7 +93,10 @@ export default function Combobox<T>({
       }}
       placeholder={placeholder}
       options={
-        (optionsLoadable.state === "hasValue" && optionsLoadable.contents.map(toOption)) ||
+        (optionsLoadable.state === "hasValue" &&
+          (optionsFilter
+            ? optionsFilter(optionsLoadable.contents)?.map(toOption)
+            : optionsLoadable.contents.map(toOption))) ||
         undefined
       }
       isDisabled={isDisabled}

--- a/frontend/src/components/DescriptiveSelector/DescriptiveSelector.tsx
+++ b/frontend/src/components/DescriptiveSelector/DescriptiveSelector.tsx
@@ -21,6 +21,7 @@ interface DescriptiveSelectorProps<T> {
   isLoading?: boolean;
   className?: string;
   contextActions?: React.ReactNode[];
+  optionsFilter?: (val: T[]) => T[] | undefined;
 }
 
 export function DescriptiveSelector<T>({

--- a/frontend/src/pages/dashboard/DashboardPage.scss
+++ b/frontend/src/pages/dashboard/DashboardPage.scss
@@ -8,29 +8,44 @@
 
 .dashboardPage {
   display: grid;
-  grid-template-rows: (170 * $px) auto;
+  grid-template-rows: auto (170 * $px) auto;
   grid-template-columns: repeat(3, 375 * $px);
   row-gap: 36 * $px;
   column-gap: 28 * $px;
 
-  &__projectSelector {
+  &__titleBlock {
+    display: flex;
     grid-row: 1/2;
+    grid-column: 1/4;
+    align-items: center;
+    justify-content: space-between;
+    height: fit-content;
+  }
+
+  &__title {
+    font-size: 1.625rem;
+    font-weight: bold;
+    color: #3a8370;
+  }
+
+  &__projectSelector {
+    grid-row: 2/3;
     grid-column: 1/2;
   }
 
   &__compoundSelector {
-    grid-row: 1/2;
+    grid-row: 2/3;
     grid-column: 2/3;
   }
 
   &__targetSelector {
-    grid-row: 1/2;
+    grid-row: 2/3;
     grid-column: 3/4;
   }
 
   &__chart {
     position: relative;
-    grid-row: 2/3;
+    grid-row: 3/4;
     grid-column: 1/3;
 
     &_size_minimized {
@@ -39,7 +54,7 @@
   }
 
   &__experiments {
-    grid-row: 2/3;
+    grid-row: 3/4;
     grid-column: 3/4;
 
     &_size_expanded {

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -49,7 +49,7 @@ export const DashboardPage: FunctionComponent = () => {
     }
   }, [loc.state, setProjectSelectedIdAtom, setCompoundSelectedIdAtom, setTargetSelectedIdAtom]);
 
-  const experimentsL = useRecoilValueLoadable(filteredExperimentsQuery);
+  const experimentsL = useRecoilValueLoadable(filteredExperimentsQuery({}));
   const [experiments, setExperiments] = useState<Experiment[] | undefined>(undefined);
 
   useEffect(() => {

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -5,6 +5,7 @@
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useRecoilValue, useRecoilValueLoadable, useSetRecoilState, waitForAll } from "recoil";
 import { useLocation } from "react-router-dom";
+import { Button } from "../../components/Button/Button";
 import PageLayout from "../../components/PageLayout/PageLayout";
 import { CompoundSelector, ProjectSelector, TargetSelector } from "./EntitySelector";
 import "./DashboardPage.scss";
@@ -38,6 +39,8 @@ export const DashboardPage: FunctionComponent = () => {
   const setProjectSelectedIdAtom = useSetRecoilState(projectSelectedIdAtom);
   const setCompoundSelectedIdAtom = useSetRecoilState(compoundIdSelectedAtom);
   const setTargetSelectedIdAtom = useSetRecoilState(targetIdSelectedAtom);
+  const experimentsL = useRecoilValueLoadable(filteredExperimentsQuery({}));
+  const [experiments, setExperiments] = useState<Experiment[] | undefined>(undefined);
 
   const loc = useLocation();
   useEffect(() => {
@@ -49,9 +52,6 @@ export const DashboardPage: FunctionComponent = () => {
     }
   }, [loc.state, setProjectSelectedIdAtom, setCompoundSelectedIdAtom, setTargetSelectedIdAtom]);
 
-  const experimentsL = useRecoilValueLoadable(filteredExperimentsQuery({}));
-  const [experiments, setExperiments] = useState<Experiment[] | undefined>(undefined);
-
   useEffect(() => {
     if (!experiments && experimentsL.state === "hasValue" && experimentsL.contents) {
       setExperiments(experimentsL.contents.experiments);
@@ -61,6 +61,19 @@ export const DashboardPage: FunctionComponent = () => {
   return (
     <PageLayout>
       <div className="dashboardPage">
+        <div className={dashboardPage("titleBlock")}>
+          <span className={dashboardPage("title")}>Dashboard</span>
+          <Button
+            type="rounded"
+            onClick={() => {
+              setProjectSelectedIdAtom(undefined);
+              setCompoundSelectedIdAtom(undefined);
+              setTargetSelectedIdAtom(undefined);
+            }}
+          >
+            Reset
+          </Button>
+        </div>
         <ProjectSelector className={dashboardPage("projectSelector")} experiments={experiments} />
         <CompoundSelector className={dashboardPage("compoundSelector")} experiments={experiments} />
         <TargetSelector className={dashboardPage("targetSelector")} experiments={experiments} />


### PR DESCRIPTION
Problem: it is possible to choose filters on dashboard page in a such way
that there will be no available experiments

Solution: filter available selector values based on other selectors

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-96

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
