### PR TITLE
[EDNA-91] Attempt to fix caching issues by disabling cache

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -61,6 +61,7 @@ in
         listen 80 default_server;
         root /usr/share/nginx/html;
         location / {
+          add_header Cache-Control 'no-store';
           try_files $uri /index.html =404;
         }
 


### PR DESCRIPTION
## Description

Incorrect caching headers for index.html might result in users seeing an old
version. To fix that, we include a Cache-Control header. Setting it to no-cache
still allows the browser to validate the cache with the upstream server, at the
cost of higher traffic to us.

Here's a link to the Cache-Control docs, for your convenience https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control

UPD: we changed this header's value to `no-store`, for details see this PR's discussion.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-91

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
