### PR TITLE
[EDNA-76] DB concurrency fixes

### DIFF
--- a/analysis/.gitignore
+++ b/analysis/.gitignore
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+__pycache__/

--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -183,6 +183,7 @@ test-suite edna-test
     , containers
     , edna
     , filepath
+    , fmt
     , hedgehog
     , hedgehog-quickcheck
     , hspec

--- a/backend/src/Edna/Setup.hs
+++ b/backend/src/Edna/Setup.hs
@@ -5,12 +5,12 @@
 module Edna.Setup
   ( Edna
   , dumpConfig
-  , runEdna
   , fromConfig
+  , runEdna
 
   , EdnaContext (..)
   , edConfig
-  , edConnectionPool
+  , edDBConnection
   , edDebugDB
   ) where
 
@@ -23,11 +23,11 @@ import RIO (RIO, runRIO)
 
 import Edna.Config.Definition (EdnaConfig)
 import Edna.Config.Environment (askDebugDB)
-import Edna.DB.Connection (ConnPool, withPostgresConn)
+import Edna.DB.Connection (PostgresConn, postgresConnPooled, withPostgresConn)
 
 data EdnaContext = EdnaContext
   { _edConfig :: !EdnaConfig
-  , _edConnectionPool :: !ConnPool
+  , _edDBConnection :: !PostgresConn
   , _edDebugDB :: !Bool
   }
 
@@ -45,7 +45,7 @@ runEdna config action = do
     debugDb <- askDebugDB
     let ednaContext = EdnaContext
           { _edConfig = config
-          , _edConnectionPool = pool
+          , _edDBConnection = postgresConnPooled pool
           , _edDebugDB = debugDb
           }
     runRIO ednaContext action

--- a/backend/src/Edna/Upload/Service.hs
+++ b/backend/src/Edna/Upload/Service.hs
@@ -86,6 +86,8 @@ uploadFile proj methodology description fileName content = do
   uploadFile' proj methodology description fileName content =<<
     either throwM pure (parseExperimentXls content)
 
+-- We have a test to check transaction rollback in case of error, which relies
+-- on the fact that we add experiment file after compounds and targets
 uploadFile' ::
   ProjectId -> MethodologyId -> Text -> Text -> LByteString ->
   FileContents -> Edna FileSummary

--- a/backend/test/Test/LibrarySpec.hs
+++ b/backend/test/Test/LibrarySpec.hs
@@ -74,10 +74,12 @@ gettersSpec = do
       targetsAscName <- getTargets (mkSortingSpec [asc #name])
         (mkPagination paginationAsc)
       checkTargets (Just (compare `on` view (_2 . _1))) (Just paginationAsc) targetsAscName
-      let paginationDesc = (3, 0)
+      let paginationDesc = (1, 0)
       targetsDescDate <- getTargets (mkSortingSpec [desc #additionDate])
         (mkPagination paginationDesc)
-      -- here sorting by date is practically equivalent to sorting by ID
+      -- here sorting by date is practically equivalent to sorting by ID,
+      -- but we need to be careful because targets added in one transaction
+      -- have equal addition date, but different IDs
       checkTargets (Just (compare `on` (Down . view _1))) (Just paginationDesc) targetsDescDate
 
   describe "getCompound" $ do
@@ -96,7 +98,7 @@ gettersSpec = do
       let paginationAsc = (4, 2)
       compoundsAsc <- getCompounds (mkSortingSpec [asc #name])
         (mkPagination paginationAsc)
-      checkCompounds (Just $ (compare `on` snd)) (Just paginationAsc) compoundsAsc
+      checkCompounds (Just (compare `on` snd)) (Just paginationAsc) compoundsAsc
       let paginationDesc = (8, 4)
       compoundsDesc <- getCompounds (mkSortingSpec [desc #name])
         (mkPagination paginationDesc)
@@ -163,10 +165,14 @@ gettersSpec = do
     projectIds :: [ProjectId]
     projectIds = map (SqlId . fst) allExpectedProjects
 
-    checkPairs :: MonadIO m =>
-      [(Word32, a)] -> ((item, a) -> Expectation) ->
-      Maybe ((Word32, a) -> (Word32, a) -> Ordering) -> Maybe (Int, Int) ->
-      [WithId idTag item] -> m ()
+    checkPairs
+      :: MonadIO m
+      => [(Word32, a)]
+      -> ((item, a) -> Expectation)
+      -> Maybe ((Word32, a) -> (Word32, a) -> Ordering)
+      -> Maybe (Int, Int)
+      -> [WithId idTag item]
+      -> m ()
     checkPairs allExpectedItems checkItem mSortCmp mTakeDrop pairs = liftIO $ do
       let expected =
             maybe id (\(toTake, toDrop) -> take toTake . drop toDrop) mTakeDrop .
@@ -179,10 +185,14 @@ gettersSpec = do
           Nothing -> expectationFailure $ "couldn't find item " <> pretty wiId
           Just a -> checkItem (wItem, a)
 
-    checkTargets :: MonadIO m =>
-      Maybe ((Word32, (Text, [Text])) -> (Word32, (Text, [Text])) -> Ordering) ->
-      Maybe (Int, Int) ->
-      [WithId 'TargetId TargetResp] -> m ()
+    checkTargets
+      :: MonadIO m
+      => Maybe ((Word32, (Text, [Text]))
+             -> (Word32, (Text, [Text]))
+             -> Ordering)
+      -> Maybe (Int, Int)
+      -> [WithId 'TargetId TargetResp]
+      -> m ()
     checkTargets = checkPairs allExpectedTargets $
       \(TargetResp {..}, (expectedName, expectedProjectNames)) -> do
         trName `shouldBe` expectedName
@@ -195,10 +205,12 @@ gettersSpec = do
       , (5, (targetName4, [projectName2]))
       ]
 
-    checkCompounds :: MonadIO m =>
-      Maybe ((Word32, Text) -> (Word32, Text) -> Ordering) ->
-      Maybe (Int, Int) ->
-      [WithId 'CompoundId CompoundResp] -> m ()
+    checkCompounds
+      :: MonadIO m
+      => Maybe ((Word32, Text) -> (Word32, Text) -> Ordering)
+      -> Maybe (Int, Int)
+      -> [WithId 'CompoundId CompoundResp]
+      -> m ()
     checkCompounds = checkPairs allExpectedCompounds $
       \(CompoundResp {..}, expectedName) -> do
         crName `shouldBe` expectedName
@@ -213,12 +225,14 @@ gettersSpec = do
       , (7, compoundName5)
       ]
 
-    checkMethodologies :: MonadIO m =>
-      Maybe ((Word32, (Text, Maybe Text, Maybe URI, Text)) ->
-             (Word32, (Text, Maybe Text, Maybe URI, Text)) ->
-              Ordering) ->
-      Maybe (Int, Int) ->
-      [WithId 'MethodologyId MethodologyResp] -> m ()
+    checkMethodologies
+      :: MonadIO m
+      => Maybe ((Word32, (Text, Maybe Text, Maybe URI, Text))
+             -> (Word32, (Text, Maybe Text, Maybe URI, Text))
+             -> Ordering)
+      -> Maybe (Int, Int)
+      -> [WithId 'MethodologyId MethodologyResp]
+      -> m ()
     checkMethodologies = checkPairs allExpectedMethodologies $
       \(MethodologyResp {..},
         (expectedName, expectedDescription, expectedConfluence, expectedProj)) -> do
@@ -232,12 +246,14 @@ gettersSpec = do
       , (2, (methodologyName2, methodologyDescription2, methodologyConfluence2, projectName2))
       ]
 
-    checkProjects :: MonadIO m =>
-      Maybe ((Word32, (Text, Maybe Text, [Text])) ->
-             (Word32, (Text, Maybe Text, [Text])) ->
-              Ordering) ->
-      Maybe (Int, Int) ->
-      [WithId 'ProjectId ProjectResp] -> m ()
+    checkProjects
+      :: MonadIO m
+      => Maybe ((Word32, (Text, Maybe Text, [Text]))
+             -> (Word32, (Text, Maybe Text, [Text]))
+             -> Ordering)
+      -> Maybe (Int, Int)
+      -> [WithId 'ProjectId ProjectResp]
+      -> m ()
     checkProjects = checkPairs allExpectedProjects $
       \(ProjectResp {..},
         (expectedName, expectedDescription, expectedCompoundNames)) -> do


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

Problem:
1. When uploadFile is called, we add various data to DB using multiple INSERT statements. We put them into transact. My idea was to achieve atomicity by this transact, but apparently it doesn't work the way I want. For example: add threadDelay $ 30 * 1000 * 1000 after insertTarget and try to upload a file. Once you click "Add experiments", go to the library. You'll see targets there, but no compounds (yet). AFAIU it means that other threads can observe the state when a file is only partially uploaded. For example, it's possible that a sub-experiment is already added, but removed measurements are not.
2. Extension of the previous one: try killing edna-server with SIGINT during threadDelay $ 30 * 1000 * 1000. If you run it again, you'll see that targets have been added and can be seen, but the rest is not. It's a more serious problem than (1) because (1) normally may last only for ≈a second, but this problem is persistent.

The root of problem:
We have three functions: `withConnection`, `transact`  and `runPg`. Function `transact` supposed to wrap some code inside transactions, and it’s working almost as expected. If we look at postgresql log we can see that transactions starts with process id `X` and ends with same one, but actions inside transaction has another id `Y`.
So, the problem is that when we call transact we use withConnection and particular actions uses withConnection too, which produces different processes.

Solution:
Store functions to work with connections in `EdnaContext` instead of `ConnPoll`, and then when we need to execute some actions in transaction - override that functions to use single connection.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves https://issues.serokell.io/issue/EDNA-76

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
