### PR TITLE
[EDNA-89] Support sorting of experiments by more fields

### DIFF
--- a/backend/src/Edna/Orphans.hs
+++ b/backend/src/Edna/Orphans.hs
@@ -10,6 +10,7 @@ module Edna.Orphans () where
 
 import Universum
 
+import Lens.Micro.Internal (Field1(..))
 import RIO (RIO(..))
 import Servant.Multipart (MultipartForm')
 import Servant.Util.Combinators.Logging (ApiCanLogArg)
@@ -28,3 +29,9 @@ instance ApiHasArgClass (MultipartForm' mods tag t) where
   apiArgName _ = "multipart"
 
 instance ApiCanLogArg (MultipartForm' mods tag t)
+
+-- defined the same way as in @Lens.Micro.Internal@ (where instances are
+-- provided only for tuples with up to 5 items)
+instance Field1 (a, b, c, d, e, f, g) (a', b, c, d, e, f, g) a a' where
+  _1 k ~(a, b, c, d, e, f, g) = (, b, c, d, e, f, g) <$> k a
+  {-# INLINE _1 #-}

--- a/backend/test/Test/DashboardSpec.hs
+++ b/backend/test/Test/DashboardSpec.hs
@@ -16,9 +16,12 @@ import qualified Data.Map.Strict as Map
 
 import RIO (runRIO)
 import Servant.Util (desc, fullContent, itemsOnPage, mkSortingSpec, noSorting, skipping)
+import Servant.Util.Dummy.Pagination (paginate)
 import Servant.Util.Internal.Util (Positive(..))
 import Test.Hspec
   (Spec, SpecWith, beforeAllWith, describe, it, shouldBe, shouldSatisfy, shouldThrow)
+
+import qualified Edna.Library.Service as Library
 
 import Edna.Analysis.FourPL (Params4PL(..), analyse4PLOne)
 import Edna.Dashboard.Error (DashboardError(..))
@@ -31,6 +34,7 @@ import Edna.Dashboard.Web.Types
   MeasurementResp(..), NewSubExperimentReq(..), SubExperimentResp(..))
 import Edna.ExperimentReader.Types
   (FileMetadata(unFileMetadata), Measurement(..), measurementToPairMaybe)
+import Edna.Library.Web.Types (MethodologyReq(..))
 import Edna.Setup (EdnaContext)
 import Edna.Util (ExperimentId, IdType(..), SqlId(..), SubExperimentId)
 import Edna.Web.Types (WithId(..))
@@ -38,6 +42,7 @@ import Edna.Web.Types (WithId(..))
 import Test.Orphans ()
 import Test.SampleData
 import Test.Setup (runTestEdna, runWithInit, withContext)
+import Test.Util (DefaultPgNullsOrder(..))
 
 spec :: Spec
 spec = withContext $ do
@@ -119,8 +124,11 @@ spec = withContext $ do
     addSampleData = do
       addSampleProjects
       addSampleMethodologies
+      toDeleteId <- wiId <$> Library.addMethodology (MethodologyReq "toDelete" Nothing Nothing)
       uploadFileTest (SqlId 1) (SqlId 1) sampleFile
-      uploadFileTest (SqlId 2) (SqlId 1) sampleFile
+      uploadFileTest (SqlId 2) (SqlId 2) sampleFile
+      uploadFileTest (SqlId 2) toDeleteId sampleFile
+      void $ Library.deleteMethodology toDeleteId
       newSubExperiment (SqlId 1) NewSubExperimentReq
         { nserName = "qwe"
         , nserChanges = mempty
@@ -131,7 +139,7 @@ spec = withContext $ do
 
     -- non-primary
     secondarySubExpId :: SubExperimentId
-    secondarySubExpId = SqlId 13
+    secondarySubExpId = SqlId (3 * sampleFileExpNum + 1)
 
 gettersSpec :: SpecWith EdnaContext
 gettersSpec = do
@@ -141,12 +149,12 @@ gettersSpec = do
         ExperimentsResp {..} <- getExperiments Nothing Nothing Nothing
           noSorting fullContent
         liftIO $ do
-          length erExperiments `shouldBe` 12
+          length erExperiments `shouldBe` 3 * sampleFileExpNum
       it "filters by project correctly" $ runTestEdna $ do
         ExperimentsResp {..} <- getExperiments (Just $ SqlId 1) Nothing Nothing
           noSorting fullContent
         liftIO $ do
-          length erExperiments `shouldBe` 6
+          length erExperiments `shouldBe` sampleFileExpNum
           forM_ erExperiments $ \(WithId _ ExperimentResp {..}) ->
             erProject `shouldBe` SqlId 1
       it "filters by project and compound correctly" $ runTestEdna $ do
@@ -175,14 +183,36 @@ gettersSpec = do
             erTarget `shouldBe` targetId
             erCompound `shouldBe` compoundId
       it "filters by project and properly applies sorting and pagination" $ runTestEdna $ do
-        ExperimentsResp {..} <- getExperiments (Just $ SqlId 1) Nothing Nothing
-          (mkSortingSpec [desc #uploadDate]) (skipping 2 $ itemsOnPage (PositiveUnsafe 3))
+        let
+          size :: Num n => n
+          size = sampleFileExpNum + 1
+          projectId = SqlId 2
+        ExperimentsResp {..} <- getExperiments (Just projectId) Nothing Nothing
+          (mkSortingSpec [desc #uploadDate]) (skipping 2 $ itemsOnPage (PositiveUnsafe size))
         liftIO $ do
-          length erExperiments `shouldBe` 3
+          length erExperiments `shouldBe` size
           forM_ erExperiments $ \(WithId _ ExperimentResp {..}) ->
-            erProject `shouldBe` SqlId 1
+            erProject `shouldBe` projectId
           let dates = map (erUploadDate . wItem) erExperiments
           sortWith Down dates `shouldBe` dates
+      it "properly sorts all experiments by various fields" $ runTestEdna $ do
+        let
+          size :: Num n => n
+          size = sampleFileExpNum + 1
+        let paginationSpec = skipping 3 $ itemsOnPage (PositiveUnsafe size)
+        let getExperiments' sorting pagination = erExperiments <$>
+              getExperiments Nothing Nothing Nothing sorting pagination
+        allExperiments <- getExperiments' noSorting fullContent
+        let getSortedIds sorting = map wiId <$> getExperiments' sorting paginationSpec
+        let
+          paginateAndGetIds :: [WithId a b] -> [SqlId a]
+          paginateAndGetIds = map wiId . paginate paginationSpec
+        descByMethodology <- getSortedIds (mkSortingSpec [desc #methodology])
+        liftIO $ do
+          let getMethodologyName (WithId sqlId er) =
+                (Down . DefaultPgNullsOrder $ snd <$> erMethodology er, Down sqlId)
+          descByMethodology `shouldBe`
+            paginateAndGetIds (sortWith getMethodologyName allExperiments)
     describe "getExperimentMetadata" $ do
       it "returns correct metadata for all known experiments" $ runTestEdna $ do
         forM_ validExperimentIds $ \expId -> do
@@ -216,7 +246,7 @@ gettersSpec = do
         runRIO ctx (getSubExperiment unknownSqlId) `shouldThrow`
           (== DESubExperimentNotFound unknownSqlId)
     describe "getMeasurements" $ do
-      it "returns correct measurements for sub-experiments 7-13" $ runTestEdna $ do
+      it "returns correct measurements for sub-experiments 13-19" $ runTestEdna $ do
         [ measurements1
           , measurements2
           , measurements3
@@ -224,7 +254,8 @@ gettersSpec = do
           , measurements5
           , measurements6
           , measurements7
-          ] <- mapM ((wItem <<$>>) . getMeasurements) (drop 6 validSubExperimentIds)
+          ] <- mapM ((wItem <<$>>) . getMeasurements) $
+            drop (2 * sampleFileExpNum) validSubExperimentIds
         let
           toMeasurementResp :: Measurement -> MeasurementResp
           toMeasurementResp Measurement {..} = MeasurementResp
@@ -246,7 +277,7 @@ gettersSpec = do
           (== DESubExperimentNotFound unknownSqlId)
 
 validSubExperimentIds :: [SubExperimentId]
-validSubExperimentIds = map SqlId [1 .. 13]
+validSubExperimentIds = map SqlId [1 .. 19]
 
 validExperimentIds :: [ExperimentId]
-validExperimentIds = map SqlId [1 .. 12]
+validExperimentIds = map SqlId [1 .. 18]

--- a/backend/test/Test/Gen.hs
+++ b/backend/test/Test/Gen.hs
@@ -170,8 +170,8 @@ genExperimentsResp =
 genExperimentResp :: MonadGen m => m ExperimentResp
 genExperimentResp = do
   erProject <- genSqlId
-  erCompound <- genSqlId
-  erTarget <- genSqlId
+  erCompound <- (,) <$> genSqlId <*> genName
+  erTarget <- (,) <$> genSqlId <*> genName
   erMethodology <- Gen.maybe $ (,) <$> genSqlId <*> genName
   erUploadDate <- genUTCTime
   erSubExperiments <- Gen.list (Range.linear 1 5) genSqlId

--- a/backend/test/Test/Gen.hs
+++ b/backend/test/Test/Gen.hs
@@ -172,7 +172,7 @@ genExperimentResp = do
   erProject <- genSqlId
   erCompound <- genSqlId
   erTarget <- genSqlId
-  erMethodology <- Gen.maybe genSqlId
+  erMethodology <- Gen.maybe $ (,) <$> genSqlId <*> genName
   erUploadDate <- genUTCTime
   erSubExperiments <- Gen.list (Range.linear 1 5) genSqlId
   erPrimarySubExperiment <- Gen.element erSubExperiments

--- a/backend/test/Test/SampleData.hs
+++ b/backend/test/Test/SampleData.hs
@@ -21,6 +21,7 @@ module Test.SampleData
 
   -- * Files
   , sampleFile
+  , sampleFileExpNum
   , sampleFile2
   , autoOutlierFile
   , sampleMetadata
@@ -76,9 +77,11 @@ projectDescription2 = Nothing
 -- Methodologies
 ----------------
 
+-- 'methodologyName1' is greater than 'methodologyName2', so that sorting
+-- by ID and name are different
 methodologyName1, methodologyName2 :: Text
-methodologyName1 = "methodology1"
-methodologyName2 = "methodology2"
+methodologyName1 = "methodologyOne"
+methodologyName2 = "methodologyAfterOne"
 
 methodologyDescription1, methodologyDescription2 :: Maybe Text
 methodologyDescription1 = Just "First methodology"
@@ -98,6 +101,14 @@ sampleFile = mkFileContents
   , (targetName2, targetMeasurements2)
   , (targetName3, targetMeasurements3)
   ]
+
+-- | Number of experiments in 'sampleFile'.
+sampleFileExpNum :: Num n => n
+sampleFileExpNum =
+  fromIntegral .
+  getSum .
+  foldMap (Sum . length . unTargetMeasurements) .
+  fcMeasurements $ sampleFile
 
 sampleFile2 :: FileContents
 sampleFile2 = mkFileContents

--- a/backend/test/Test/Util.hs
+++ b/backend/test/Test/Util.hs
@@ -5,12 +5,28 @@
 -- | Utilities used only in tests.
 
 module Test.Util
-  ( methodologyReqToResp
+  ( DefaultPgNullsOrder (..)
+  , methodologyReqToResp
   ) where
 
 import Universum
 
 import Edna.Library.Web.Types (MethodologyReq(..), MethodologyResp(..))
+
+-- | According to <https://www.postgresql.org/docs/current/sql-select.html>:
+-- the default is to act as though nulls are larger than non-nulls.
+-- Ideally we should pass @NULLS FIRST@ or @NULLS LAST@ explicitly, but it's not
+-- supported by @servant-util@ yet.
+-- This newtype changes the 'Ord' instance for anything wrapped into 'Maybe' to
+-- treat 'Nothing' values greater than 'Just'.
+newtype DefaultPgNullsOrder a = DefaultPgNullsOrder (Maybe a)
+  deriving stock (Eq)
+
+instance Ord a => Ord (DefaultPgNullsOrder a) where
+  DefaultPgNullsOrder a <= DefaultPgNullsOrder b = case (a, b) of
+    (_, Nothing) -> True
+    (Nothing, Just _) -> False
+    (Just a', Just b') -> a' <= b'
 
 -- | Created 'MethodologyResp' from 'MethodologyReq' with a list of project names.
 methodologyReqToResp :: MethodologyReq -> [Text] -> MethodologyResp

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -104,9 +104,9 @@ export type CompoundDto = {
 
 export type ExperimentDto = Dto<{
   project: number;
-  compound: number;
-  target: number;
-  methodology?: number;
+  compound: [number, string];
+  target: [number, string];
+  methodology?: [number, string];
   uploadDate: DateTimeDto;
   subExperiments: number[];
   primarySubExperiment: number;

--- a/frontend/src/components/IC50Line/IC50Tooltip.scss
+++ b/frontend/src/components/IC50Line/IC50Tooltip.scss
@@ -7,6 +7,10 @@
 @import "src/styles/variables";
 
 .ic50value {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
   &__none {
     width: 10 * $px;
     height: 1 * $px;

--- a/frontend/src/components/Table/Table.scss
+++ b/frontend/src/components/Table/Table.scss
@@ -6,18 +6,22 @@
 
 @import "src/styles/variables";
 
-$cell-indent: 22 * $px;
+$cell-indent: 21 * $px;
 
 .ednaTable {
   $border-color: #dfe3e3;
-  $head-vertical-padding: 20 * $px;
+  $head-vertical-padding: 21 * $px;
   $head-line-height: 18 * $px;
 
   width: 100%;
   border-spacing: 0;
 
+  &_fixed {
+    table-layout: fixed;
+  }
+
   &__sortSign {
-    margin-left: 22 * $px;
+    margin-left: 10 * $px;
     visibility: hidden;
 
     &_desc {
@@ -36,11 +40,9 @@ $cell-indent: 22 * $px;
     top: 0;
     z-index: 1;
     padding: $head-vertical-padding 0 $head-vertical-padding $cell-indent;
-
     font-size: 14 * $px;
     font-weight: 500;
     line-height: $head-line-height;
-
     color: $color-black;
     text-align: left;
     background-color: white;
@@ -53,10 +55,31 @@ $cell-indent: 22 * $px;
     &:hover .ednaTable__sortSign {
       visibility: visible;
     }
+
+    &_light {
+      color: gray;
+    }
+
+    &_compound {
+      width: 33.3%;
+    }
+
+    &_target {
+      width: 33.3%;
+    }
+
+    &_IC50 {
+      width: 17.5%;
+    }
+
+    &_checkmark {
+      width: 15.8%;
+    }
   }
 
   &__headRightBorder {
     $height: 20 * $px;
+
     position: absolute;
     top: (2 * $head-vertical-padding + $head-line-height - $height) / 2;
     right: 0;

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -20,6 +20,7 @@ interface ColumnExtra {
 interface TableProps<T extends object> {
   columns: Column<T>[];
   columnExtras?: { [id: string]: ColumnExtra };
+  headerExtraStyles?: { [id: string]: string };
   className?: string;
   small?: boolean;
   collapsible?: (x: T) => React.ReactNode;
@@ -33,6 +34,7 @@ interface TableProps<T extends object> {
 export function Table<T extends object>({
   columns,
   columnExtras,
+  headerExtraStyles,
   className,
   small,
   collapsible,
@@ -169,7 +171,9 @@ export function Table<T extends object>({
               return (
                 <th
                   {...column.getHeaderProps(column.getSortByToggleProps())}
-                  className="ednaTable__columnHead"
+                  className={`ednaTable__columnHead ${
+                    headerExtraStyles ? headerExtraStyles[column.id] : ""
+                  }`}
                   title={column.canSort ? `Sort by ${column.Header}` : ""}
                 >
                   {column.render("Header")}

--- a/frontend/src/components/Tooltip/Tooltip.scss
+++ b/frontend/src/components/Tooltip/Tooltip.scss
@@ -8,18 +8,13 @@
 
 .tooltipContainer {
   position: relative;
-  line-height: 0;
-  text-align: center;
 
   &__tooltip {
     position: absolute;
-    bottom: -26 * $px;
-    left: -50%;
-
+    left: -3rem;
     z-index: 1;
     display: none;
     padding: (2 * $px) (8 * $px);
-
     font-size: 12 * $px;
     line-height: 16 * $px;
     color: white;

--- a/frontend/src/pages/dashboard/ExperimentsTable/ExperimentsTable.scss
+++ b/frontend/src/pages/dashboard/ExperimentsTable/ExperimentsTable.scss
@@ -67,7 +67,7 @@
   &__checkmark {
     position: absolute;
     top: 0;
-    left: 0;
+    left: 0.5rem;
     width: 1rem;
     height: 1rem;
     background-color: white;

--- a/frontend/src/pages/dashboard/ExperimentsTable/ExperimentsTable.tsx
+++ b/frontend/src/pages/dashboard/ExperimentsTable/ExperimentsTable.tsx
@@ -109,6 +109,7 @@ export function ExperimentsTableSuspendable({
     () => ({
       Header: "Compound",
       id: "compound",
+      minWidth: 124,
       accessor: (e: Experiment) => e.compoundName,
     }),
     []
@@ -127,7 +128,7 @@ export function ExperimentsTableSuspendable({
     () => ({
       Header: "IC50",
       disableSortBy: true,
-      accessor: (e: Experiment) => <IC50Tooltip ic50={e.primaryIC50} />,
+      accessor: (e: Experiment) => <IC50Tooltip ic50={e.primaryIC50} className="ic50value" />,
     }),
     []
   );
@@ -236,12 +237,19 @@ export function ExperimentsTableSuspendable({
           </div>
           <div className="tableContainer experimentsArea__experimentsTableContainer">
             <Table<Experiment>
+              className={expTableSize === "minimized" ? "ednaTable_fixed" : ""}
               defaultSortedColumn="uploadDate"
               small
               columns={expTableSize === "minimized" ? minimizedColumns : expandedColumns}
               dataOrQuery={params => shownExperiments([showEntries, params])}
               columnExtras={{
                 show: { manualCellRendering: true },
+              }}
+              headerExtraStyles={{
+                show: expTableSize === "minimized" ? "ednaTable__columnHead_checkmark" : "",
+                compound: expTableSize === "minimized" ? "ednaTable__columnHead_compound" : "",
+                target: expTableSize === "minimized" ? "ednaTable__columnHead_target" : "",
+                IC50: expTableSize === "minimized" ? "ednaTable__columnHead_IC50" : "",
               }}
               collapsible={e => (
                 <SuspenseSpinner>

--- a/frontend/src/pages/dashboard/ExperimentsTable/ExperimentsTable.tsx
+++ b/frontend/src/pages/dashboard/ExperimentsTable/ExperimentsTable.tsx
@@ -108,7 +108,7 @@ export function ExperimentsTableSuspendable({
   const compoundColumn = React.useMemo(
     () => ({
       Header: "Compound",
-      disableSortBy: true,
+      id: "compound",
       accessor: (e: Experiment) => e.compoundName,
     }),
     []
@@ -117,7 +117,7 @@ export function ExperimentsTableSuspendable({
   const targetColumn = React.useMemo(
     () => ({
       Header: "Target",
-      disableSortBy: true,
+      id: "target",
       accessor: (e: Experiment) => e.targetName,
     }),
     []
@@ -175,7 +175,7 @@ export function ExperimentsTableSuspendable({
       ic50Column,
       {
         Header: "Methodology",
-        disableSortBy: true,
+        id: "methodology",
         accessor: (e: Experiment) => e.methodologyName,
       },
       {

--- a/frontend/src/store/selectors.ts
+++ b/frontend/src/store/selectors.ts
@@ -154,18 +154,13 @@ export const filteredExperimentsQuery = selectorFamily<ExperimentsWithMean, Sort
     }
 
     const projects = get(projectsQuery({}));
-    const compounds = get(compoundsQuery({}));
-    const targets = get(targetsQuery({}));
-    const methodologies = get(methodologiesQuery({}));
 
     const exps: Experiment[] = experiments
       .map(e => {
         const projectName = findName(projects, e.item.project);
-        const compoundName = findName(compounds, e.item.compound);
-        const targetName = findName(targets, e.item.target);
-        const methodologyName = e.item.methodology
-          ? findName(methodologies, e.item.methodology)
-          : undefined;
+        const compoundName = e.item.compound[1];
+        const targetName = e.item.target[1];
+        const methodologyName = e.item.methodology ? e.item.methodology[1] : undefined;
         return {
           id: e.id,
           projectName,

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -49,8 +49,46 @@ export function zip<A, B>(a: A[], b: B[]): [A, B][] {
   return a.map((e, i) => [e, b[i]]);
 }
 
+// We show at most 5 characters. We empirically determined that 5 characters
+// can be fit into the IC50 column.
+// If we return a string that doesn't fit into the column for some reason,
+// we have fallback logic in CSS that limits the width and adds ellipsis.
 export function formatIC50(x: number): string {
-  return x.toFixed(3);
+  // We are carefully listing all cases here to think about each of them.
+  // Perhaps it can be optimized, e. g. using 'toPrecision', but I (@gromak)
+  // decided to follow the KISS principle.
+  switch (true) {
+    // More than 5 digits in total.
+    // We show it in exponential notation with just one significant digit.
+    // Usually such large values mean that the model is bad and the exact value
+    // doesn't matter.
+    case x >= 1e5:
+      return x.toExponential(0);
+
+    // 5 or 4 digits in total, no digits after decimal point.
+    case x >= 1e3:
+      return x.toFixed(0);
+
+    // 3 digits before the decimal point, 1 after.
+    case x >= 1e2:
+      return x.toFixed(1);
+
+    // 2 digits before the decimal point, 2 after.
+    case x >= 10:
+      return x.toFixed(2);
+
+    // 1 digit before the decimal point, 3 after.
+    case x >= 1:
+      return x.toFixed(3);
+
+    // '0' before the decimal point, 3 digits after.
+    case x >= 1e-4:
+      return x.toFixed(3);
+
+    // Very small value, just show exponential format with one significat digit.
+    default:
+      return x.toExponential(0);
+  }
 }
 
 export function useClickOutsideCallback(ref: RefObject<HTMLElement>, onOutside: () => void): void {


### PR DESCRIPTION
## Description

Problem: it's possible to sort experiments by upload date, but there
are other columns in the table with experiments and it often makes
sense to sort by them as well.

Solution:
- [x] Support sorting by compound, target and methodology names.
- [x] Add these names to `ExperimentResp`.
- [x] Add implicit base sorting by IDs, so that items with equal sorting keys (or all items when there is no sorting) always have deterministic order.
- [x] Update frontend according to new (extended) `ExperimentResp` structure.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-89

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
