### PR TITLE
[EDNA-116] Set correct creation date of Docker images

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -66,9 +66,11 @@ steps:
     branches: "demo"
   - label: Push backend image to registry
     commands:
-      - nix-shell --run 'scripts/docker-push.sh docker-archive:$(nix-build -A packages.x86_64-linux.docker-backend) docker://ghcr.io/serokell/edna-backend:latest'
+      - CURRENT_DATE=$(date --iso-8601=seconds)
+      - nix-shell --run 'scripts/docker-push.sh docker-archive:$(nix-build -A packages.x86_64-linux.docker-backend --argstr creationDate "$CURRENT_DATE") docker://ghcr.io/serokell/edna-backend:latest'
     branches: "master"
   - label: Push frontend image to registry
     commands:
-      - nix-shell --run 'scripts/docker-push.sh docker-archive:$(nix-build -A packages.x86_64-linux.docker-frontend) docker://ghcr.io/serokell/edna-frontend:latest'
+      - CURRENT_DATE=$(date --iso-8601=seconds)
+      - nix-shell --run 'scripts/docker-push.sh docker-archive:$(nix-build -A packages.x86_64-linux.docker-frontend --argstr creationDate "$CURRENT_DATE") docker://ghcr.io/serokell/edna-frontend:latest'
     branches: "master"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,10 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+# Doesn't need to be precise
+env:
+    CURRENT_DATE: $(date --iso-8601=seconds)
+
 steps:
 # Checks for the whole repo
   - label: check trailing whitespace
@@ -29,7 +33,7 @@ steps:
       - nix-build -A checks.x86_64-linux.backend-test
   - label: backend image
     commands:
-      - nix-build -A packages.x86_64-linux.docker-backend
+      - nix-build -A packages.x86_64-linux.docker-backend --argstr creationDate "$CURRENT_DATE"
       - buildkite-agent artifact upload "$(readlink -f result)"
   - label: backend hlint
     commands:
@@ -41,7 +45,7 @@ steps:
       - nix-build -A packages.x86_64-linux.frontend
   - label: frontend image
     commands:
-      - nix-build -A packages.x86_64-linux.docker-frontend
+      - nix-build -A packages.x86_64-linux.docker-frontend --argstr creationDate "$CURRENT_DATE"
       - buildkite-agent artifact upload "$(readlink -f result)"
   - label: frontend tscompile
     commands:
@@ -66,11 +70,9 @@ steps:
     branches: "demo"
   - label: Push backend image to registry
     commands:
-      - CURRENT_DATE=$(date --iso-8601=seconds)
       - nix-shell --run 'scripts/docker-push.sh docker-archive:$(nix-build -A packages.x86_64-linux.docker-backend --argstr creationDate "$CURRENT_DATE") docker://ghcr.io/serokell/edna-backend:latest'
     branches: "master"
   - label: Push frontend image to registry
     commands:
-      - CURRENT_DATE=$(date --iso-8601=seconds)
       - nix-shell --run 'scripts/docker-push.sh docker-archive:$(nix-build -A packages.x86_64-linux.docker-frontend --argstr creationDate "$CURRENT_DATE") docker://ghcr.io/serokell/edna-frontend:latest'
     branches: "master"

--- a/docker.nix
+++ b/docker.nix
@@ -9,7 +9,8 @@
 , glibcLocales
 , linkFarm
 , runCommand
-, writeTextDir }:
+, writeTextDir
+, creationDate }:
 
 let
   inherit (dockerTools) buildLayeredImage buildImage pullImage;
@@ -26,6 +27,7 @@ in
   in buildLayeredImage {
     name = "ghcr.io/serokell/edna-backend";
     tag = "latest";
+    created = creationDate;
 
     contents = [
       backend
@@ -78,6 +80,7 @@ in
   in buildImage {
     name = "ghcr.io/serokell/edna-frontend";
     tag = "latest";
+    created = creationDate;
     fromImage = nginx;
     contents = [
       html

--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,6 @@
       };
       docker = pkgs.callPackage ./docker.nix {
         backend = backend.server;
-        inherit creationDate;
         inherit frontend;
       };
 
@@ -100,8 +99,8 @@
         analysis-env = analysis-env;
         backend-lib = backend.library;
         backend-server = backend.server;
-        docker-backend = docker.backend-image;
-        docker-frontend = docker.frontend-image;
+        docker-backend = { creationDate ? "1970-01-01T00:00:01Z" }: (docker creationDate).backend-image;
+        docker-frontend = { creationDate ? "1970-01-01T00:00:01Z" }: (docker creationDate).frontend-image;
         frontend = frontend;
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -39,9 +39,9 @@
         profile = with self.packages.${system};
           linkFarm "edna-deploy-profile" [
             { name = "backend.tar.gz";
-            path = docker-backend; }
+            path = docker-backend { }; }
             { name = "frontend.tar.gz";
-            path = docker-frontend; }
+            path = docker-frontend { }; }
           ];
       in {
         hostname = "${hostName}.edna.serokell.team";

--- a/flake.nix
+++ b/flake.nix
@@ -80,9 +80,10 @@
         inherit analysis-env;
         EDNA_ANALYSIS_DIR = ./analysis;
       };
-      docker = pkgs.callPackage ./docker.nix {
+      docker = creationDate: pkgs.callPackage ./docker.nix {
         backend = backend.server;
         inherit frontend;
+        creationDate = creationDate;
       };
 
       frontend = pkgs.callPackage ./frontend { };

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,7 @@
       };
       docker = pkgs.callPackage ./docker.nix {
         backend = backend.server;
+        inherit creationDate;
         inherit frontend;
       };
 


### PR DESCRIPTION
## Description

We don't set `created` passed to `buildLayeredImage`/`buildImage` and thus it's set to the date more than 50 years ago.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves https://issues.serokell.io/issue/EDNA-116

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
