### PR TITLE
[EDNA-128] Add edna-generator

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -26,6 +26,8 @@ ifeq (${EDNA_USE_CABAL},1)
 		--color $(TEST_ARGUMENTS)
 	call_server = cabal new-run $(PACKAGE):edna-server $(CABAL_BUILD_OPTIONS) -- \
 		$(RUN_ARGUMENTS)
+	call_generator = cabal new-run $(PACKAGE):edna-generator $(CABAL_BUILD_OPTIONS) -- \
+		$(RUN_ARGUMENTS)
 	call_clean = cabal new-clean
 else
 	call_build = stack build $(STACK_BUILD_OPTIONS) --file-watch $(PACKAGE)
@@ -33,6 +35,8 @@ else
 	call_test = stack build $(STACK_TEST_OPTIONS) $(PACKAGE) \
 		--test-arguments "--color $(TEST_ARGUMENTS)"
 	call_server = stack run edna-server -- \
+		$(RUN_ARGUMENTS)
+	call_generator = stack run edna-generator -- \
 		$(RUN_ARGUMENTS)
 	call_clean = stack clean $(PACKAGE)
 endif
@@ -54,6 +58,12 @@ test:
 run:
 	cd ../analysis && poetry install && \
 		poetry run bash -c "cd ../backend && $(call call_server)"
+
+# Run edna-generator inside `poetry shell` making sure Python analysis will work.
+# If you want to pass additional arguments, use `RUN_ARGUMENTS` env variable.
+run-generator:
+	cd ../analysis && poetry install && \
+		poetry run bash -c "cd ../backend && $(call call_generator)"
 
 clean:
 	$(call call_clean)

--- a/backend/README.md
+++ b/backend/README.md
@@ -48,3 +48,19 @@ NOTE: priority of configurations is following: command line arguments, environme
 To run tests you need to have [`pg_tmp`](http://eradman.com/ephemeralpg/) to run DB for tests.
 Then run `make test` to execute tests.
 This command automatically executes [`poetry`](https://python-poetry.org/) to obtain Python dependencies.
+
+## Generate sample data
+
+Apart from `edna-server` executable we provide `edna-generator`.
+This tool can generate sample data for Edna and put it into DB.
+You can build and run it the same way as `edna-server` (via `stack` or `cabal`).
+You can also run it using [`Makefile`](./Makefile).
+It has the same options as `edna-server` plus some additional options that specify how much data to generate.
+Pass `--help` to get the full list of available options.
+
+You are adviced to set logging to `prod` or `nothing` (otherwise there will be too much output in logs)
+Also maybe you also want to run it on empty DB.
+Example with `prod` logging and empty DB: `RUN_ARGUMENTS='-c dev-config.yaml -l prod --init-mode enable-with-drop' make run-generator`.
+If DB is not empty and there are conflicts (such as already existing project name), by default they will be skipped.
+
+Note that `edna-generator` is an experimental tool for developers and may be unstable/unreliable sometimes.

--- a/backend/edna.cabal
+++ b/backend/edna.cabal
@@ -55,6 +55,7 @@ library
       Edna.ExperimentReader.Error
       Edna.ExperimentReader.Parser
       Edna.ExperimentReader.Types
+      Edna.Init
       Edna.Library.DB.Query
       Edna.Library.DB.Schema
       Edna.Library.Error
@@ -133,6 +134,22 @@ executable edna-server
   build-depends:
       edna,
       optparse-applicative,
+      with-utf8
+
+executable edna-generator
+  import: common-options
+  main-is: Main.hs
+  other-modules:
+      Generator
+  hs-source-dirs:
+      generator
+  build-depends:
+      bytestring,
+      containers,
+      edna,
+      optparse-applicative,
+      safe-exceptions,
+      text,
       with-utf8
 
 test-suite edna-test

--- a/backend/generator/Generator.hs
+++ b/backend/generator/Generator.hs
@@ -1,0 +1,162 @@
+-- SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+module Generator
+  ( GeneratorSpec (..)
+  , generatorDetails
+  , generateAndSave
+  ) where
+
+import Universum
+
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as Text
+
+import Control.Exception.Safe (throwString)
+import Options.Applicative.Help.Pretty (Doc, indent, linebreak)
+
+import qualified Edna.Library.Service as Library
+import qualified Edna.Upload.Service as Upload
+
+import Edna.ExperimentReader.Types
+  (FileContents(..), FileMetadata(..), Measurement(..), TargetMeasurements(..))
+import Edna.Init (initEdna)
+import Edna.Library.Error (LibraryError(..))
+import Edna.Library.Web.Types (MethodologyReq(..), ProjectReq(..))
+import Edna.Logging (logMessage)
+import Edna.Setup (Edna)
+import Edna.Util (SqlId(..))
+
+-- | Underlying numeric type used in 'SqlId'. We use it as an index in most
+-- cases here.
+type Idx = Word32
+
+-- | Specification for data generator: determines what data will be generated.
+--
+-- 'Word' seems to be the most appropriate type for indices, but here we use
+-- 'Word32' aka 'Idx' in most cases because it's convenient to wrap into 'SqlId'.
+-- We don't use it for measurements because here we don't construct measurement
+-- IDs and add them to other indices.
+data GeneratorSpec = GeneratorSpec
+  { gsProjectNum :: Idx
+  -- ^ How many projects to generate.
+  , gsMethodologyNum :: Idx
+  -- ^ How many methodologies to generate.
+  , gsCompoundNum :: Idx
+  -- ^ How many compounds to put into one file.
+  , gsTargetNum :: Idx
+  -- ^ How many targets to put into one file.
+  , gsMeasurementsNum :: Word
+  -- ^ Number of measurements in one experiment.
+  , gsStrict :: Bool
+  -- ^ Whether to fail in case of duplicates.
+  }
+
+-- | Detailed description of data generation procedure.
+generatorDetails :: Doc
+generatorDetails = mconcat
+  [ "First we generate the requested number of projects and methodologies."
+  , linebreak
+  , "Then for each project and methodology a file is uploaded."
+  , linebreak
+  , "It has `--compounds` compounds and `--targets` targets, one experiment for each."
+  , linebreak
+  , "Each project has different compounds and targets."
+  , linebreak
+  , "The total number of entities is:"
+  , linebreak
+  , indent 2 $ mconcat
+    [ "• `p` projects"
+    , linebreak
+    , "• `m` methodologies"
+    , linebreak
+    , "• `p * c` compounds and `p * t` targets"
+    , linebreak
+    , "• `p * m * c * t` experiments"
+    ]
+  ]
+
+-- | Generate some dummy data and save it to DB according to the provided spec.
+generateAndSave :: GeneratorSpec -> Edna ()
+generateAndSave spec@GeneratorSpec {..} = do
+  initEdna
+
+  unless (gsCompoundNum > 0 && gsTargetNum > 0) $
+    throwString "Number of compounds and targets must be positive"
+
+  mapM_ addProject [1 .. gsProjectNum]
+  logMessage $ "Added " <> show gsProjectNum <> " projects"
+
+  mapM_ addMethodology [1 .. gsMethodologyNum]
+  logMessage $ "Added " <> show gsMethodologyNum <> " methodologies"
+
+  addExperiments spec
+  where
+    addProject i = void (Library.addProject ProjectReq
+      { prqName = "Project #" <> show i
+      , prqDescription = show i <$ guard (even i)
+      }) `catch` \case
+        LEProjectNameExists {} | not gsStrict -> pass
+        e -> throwM e
+
+    addMethodology i = void (Library.addMethodology MethodologyReq
+      { mrqName = "Methodology #" <> show i
+      , mrqDescription = show i <$ guard (even i)
+      , mrqConfluence = Nothing
+      }) `catch` \case
+        LEMethodologyNameExists {} | not gsStrict -> pass
+        e -> throwM e
+
+addExperiments :: GeneratorSpec -> Edna ()
+addExperiments spec@GeneratorSpec {..} = do
+  forM_ [1 .. gsProjectNum] $ \projectIdx -> do
+    forM_ [1 .. gsMethodologyNum] $ \methodologyIdx ->
+      addExperiment projectIdx methodologyIdx
+    logMessage $ "Processed project " <> show projectIdx
+  where
+    addExperiment :: Idx -> Idx -> Edna ()
+    addExperiment projectId methodologyId = do
+      let description =
+            Text.replicate 100 (show projectId) <>
+            Text.replicate 100 (show methodologyId)
+      let metadata = replicate 100 (Text.replicate 1000 "x")
+      let fc = FileContents
+            { fcMeasurements = fileMeasurements spec projectId methodologyId
+            , fcMetadata = FileMetadata metadata
+            }
+      let blob = BSL.replicate 3e5 0x42
+      void $ Upload.uploadFile' (SqlId projectId) (SqlId methodologyId)
+        description "experiment.xlsx" blob fc
+
+fileMeasurements :: GeneratorSpec -> Idx -> Idx -> Map Text TargetMeasurements
+fileMeasurements GeneratorSpec {..} projectIdx methodologyIdx =
+  Map.fromList $ flip map [0 .. gsTargetNum - 1] $ \targetIdx ->
+    let
+      targetIdx' = (projectIdx - 1) * gsTargetNum + targetIdx
+      targetName = "TARGET number " <> show targetIdx'
+    in (targetName,) . TargetMeasurements . Map.fromList $
+      flip map [0 .. gsCompoundNum - 1] $ \compoundIdx ->
+        let
+          compoundIdx' = (projectIdx - 1) * gsCompoundNum + compoundIdx
+          compoundName = "COMPOUND number " <> show compoundIdx'
+        in (compoundName, measurements gsMeasurementsNum projectIdx methodologyIdx)
+
+measurements :: Word -> Idx -> Idx -> [Measurement]
+measurements n project methodology = map measurement [1 .. n]
+  where
+    -- 4PL is computed as @f(x) = d + (a - d) / (1 + (x / c)^b)@.
+    -- Below we set @a@ to project index, @b@ to 1, @c@ to methodology index and @d@ to 0.
+    -- We also add some small value @eps@.
+    measurement i =
+      let
+        concentration = 200 / 2 ^ i
+        signal = realToFrac project / (1 + (concentration / realToFrac methodology))
+        signalWithEps = signal + -1 ^ i * eps i
+      in Measurement
+      { mConcentration = concentration
+      , mSignal = signalWithEps
+      , mIsOutlier = i == 5
+      }
+    eps i = realToFrac (project * methodology) / (1e2 * realToFrac i)

--- a/backend/generator/Main.hs
+++ b/backend/generator/Main.hs
@@ -1,0 +1,76 @@
+-- SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+{-# LANGUAGE ApplicativeDo #-}
+
+module Main
+  ( main
+  ) where
+
+import Universum
+
+import Main.Utf8 (withUtf8)
+import Options.Applicative
+  (Parser, ParserInfo, auto, execParser, footerDoc, fullDesc, help, helper, info, long, option,
+  progDesc, showDefault, switch, value)
+
+import Edna.Config.CLA (EdnaOptions, ednaOptsParser)
+import Edna.Config.Prepare (prepareConfig)
+import Edna.Setup (runEdna)
+
+import Generator (GeneratorSpec(..), generateAndSave, generatorDetails)
+
+main :: IO ()
+main = withUtf8 $ do
+  (options, generatorSpec) <- execParser parserInfo
+  config <- prepareConfig options
+  runEdna config $ generateAndSave generatorSpec
+
+----------------
+-- Command line
+----------------
+
+parserInfo :: ParserInfo (EdnaOptions, GeneratorSpec)
+parserInfo = info (parser <**> helper) $
+  fullDesc <> progDesc "Sample data generator for Edna" <> footerDoc (Just generatorDetails)
+  where
+    parser = (,) <$> ednaOptsParser <*> generatorSpecParser
+
+generatorSpecParser :: Parser GeneratorSpec
+generatorSpecParser = do
+  gsProjectNum <- option auto $ mconcat
+    [ long "projects"
+    , value 4
+    , showDefault
+    , help "Total number of projects to generate"
+    ]
+  gsMethodologyNum <- option auto $ mconcat
+    [ long "methodologies"
+    , value 6
+    , showDefault
+    , help "Total number of methodologies to generate"
+    ]
+  gsCompoundNum <- option auto $ mconcat
+    [ long "compounds"
+    , value 5
+    , showDefault
+    , help "Number of compounds in one file"
+    ]
+  gsTargetNum <- option auto $ mconcat
+    [ long "targets"
+    , value 5
+    , showDefault
+    , help "Number of targets in one file"
+    ]
+  gsMeasurementsNum <- option auto $ mconcat
+    [ long "measurements"
+    , value 10
+    , showDefault
+    , help "Number of measurements in one experiment"
+    ]
+  gsStrict <- switch $ mconcat
+    [ long "strict"
+    , help "Fail on duplicates instead of skipping them"
+    ]
+  pure GeneratorSpec {..}

--- a/backend/src/Edna/Config/CLA.hs
+++ b/backend/src/Edna/Config/CLA.hs
@@ -5,6 +5,7 @@
 module Edna.Config.CLA
   ( EdnaOptions(..)
   , ednaOpts
+  , ednaOptsParser
   ) where
 
 import Universum
@@ -17,7 +18,7 @@ import Edna.Config.Definition (LoggingConfig(..), parseLoggingConfig)
 import Edna.Util (ConnString(..), DatabaseInitOption, NetworkAddress, parseDatabaseInitOption)
 
 ednaOpts :: ParserInfo EdnaOptions
-ednaOpts = info (ednaOpts' <**> helper) $
+ednaOpts = info (ednaOptsParser <**> helper) $
   fullDesc <> progDesc "Edna API server"
 
 data EdnaOptions = EdnaOptions
@@ -33,17 +34,17 @@ data EdnaOptions = EdnaOptions
   } deriving stock (Generic, Show)
 
 
-ednaOpts' :: Parser EdnaOptions
-ednaOpts' = EdnaOptions
-        <$> configParser
-        <*> apiListenAddrParser
-        <*> apiServeDocsParser
-        <*> dbConnStringParser
-        <*> dbMaxConnectionsParser
-        <*> dbInitialisationModeParser
-        <*> dbInitialisationInitScriptParser
-        <*> loggingParser
-        <*> dumpConfigParser
+ednaOptsParser :: Parser EdnaOptions
+ednaOptsParser = EdnaOptions
+  <$> configParser
+  <*> apiListenAddrParser
+  <*> apiServeDocsParser
+  <*> dbConnStringParser
+  <*> dbMaxConnectionsParser
+  <*> dbInitialisationModeParser
+  <*> dbInitialisationInitScriptParser
+  <*> loggingParser
+  <*> dumpConfigParser
 
 
 configParser :: Parser (Maybe FilePath)

--- a/backend/src/Edna/Init.hs
+++ b/backend/src/Edna/Init.hs
@@ -1,0 +1,29 @@
+-- SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+-- | Edna initialization shared by code that runs 'Edna' actions.
+
+module Edna.Init
+  ( initEdna
+  ) where
+
+import Universum
+
+import RIO (BufferMode(LineBuffering), hSetBuffering)
+
+import Edna.Analysis.FourPL (check4PLConfiguration)
+import Edna.DB.Initialisation (schemaInit)
+import Edna.Setup (Edna)
+
+-- | Actions that are typically performed before running some 'Edna' action:
+--
+-- * Setup logging.
+-- * Check Python environment.
+-- * Initialize DB.
+initEdna :: Edna ()
+initEdna = do
+    -- We print logs to stderr and LineBuffering is most appropriate for logging.
+  hSetBuffering stderr LineBuffering
+  check4PLConfiguration
+  schemaInit

--- a/backend/src/Edna/Web/Server.hs
+++ b/backend/src/Edna/Web/Server.hs
@@ -19,17 +19,16 @@ import qualified Network.Wai.Handler.Warp as Warp
 import Network.Wai.Middleware.Prometheus (PrometheusSettings(..), prometheus)
 import Network.Wai.Middleware.RequestLogger
   (Destination(..), IPAddrSource(..), OutputFormat(..), RequestLoggerSettings(..), mkRequestLogger)
-import RIO (BufferMode(LineBuffering), hSetBuffering, runRIO)
 import Prometheus (register)
 import Prometheus.Metric.GHC (ghcMetrics)
+import RIO (runRIO)
 import Servant (Application, Handler, Server, hoistServer, serve, throwError)
 import Servant.Util.Combinators.Logging (ServantLogConfig(..), serverWithLogging)
 
-import Edna.Analysis.FourPL (check4PLConfiguration)
 import Edna.Config.Definition (LoggingConfig(..), acListenAddr, acServeDocs, ecApi, ecLogging)
-import Edna.DB.Initialisation (schemaInit)
 import Edna.Dashboard.Error (DashboardError)
 import Edna.ExperimentReader.Error (ExperimentParsingError)
+import Edna.Init (initEdna)
 import Edna.Library.Error (LibraryError)
 import Edna.Logging (logUnconditionally)
 import Edna.Orphans ()
@@ -90,10 +89,7 @@ ednaToHandler ctx action =
 -- | Runs the web server which serves Edna API.
 edna :: Edna ()
 edna = do
-  -- We print logs to stderr and LineBuffering is most appropriate for logging.
-  hSetBuffering stderr LineBuffering
-  check4PLConfiguration
-  schemaInit
+  initEdna
   listenAddr <- fromConfig $ ecApi . acListenAddr
   withDocs <- fromConfig $ ecApi . acServeDocs
   loggingConfig <- fromConfig ecLogging


### PR DESCRIPTION
## Description

Problem: for testing we often need to add some sample data to DB,
doing it manually is tedious and for stress testing it's almost
infeasible.

Solution: add a new edna-generator executable capable of generating
some hardcoded data and saving it to DB.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-128

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

No tests because this utility is just for developers. We may use it in a benchmark at some point.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
