### PR TITLE
[EDNA-117] Generate proper MDe links

### DIFF
--- a/backend/dev-config.yaml
+++ b/backend/dev-config.yaml
@@ -21,3 +21,6 @@ db:
 
 # Other possible values: "prod" and "nothing".
 logging: "dev"
+
+# Note that this is stub and you should set your compound storage host
+mde-host: "https://mde.edna/list"

--- a/backend/scripts/test.bats
+++ b/backend/scripts/test.bats
@@ -19,6 +19,7 @@ function teardown() {
   unset POSTGRES_USER
   unset POSTGRES_PASSWORD
   unset POSTGRES_DB
+  unset EDNA_MDE_HOST
 }
 
 @test "Passing wrong EDNA_API_LISTEN CLA causes error" {
@@ -165,6 +166,7 @@ function teardown() {
                   --init-mode "enable" \
                   --init-script "/init.sql" \
                   --logging dev \
+                  --mde-host "https://mde.edna/list" \
                   --dump-config
 
   assert_success
@@ -178,6 +180,7 @@ function teardown() {
   assert_line --index 8 "    mode: enable"
   assert_line --index 9 "  conn-string: host=/run/postgresql dbname=edna host=localhost dbname=edna"
   assert_line --index 10 "  max-connections: 1"
+  assert_line --index 11 "mde-host: https://mde.edna/list"
 }
 
 @test "Passing envs modifes config" {
@@ -192,6 +195,7 @@ function teardown() {
   export POSTGRES_PASSWORD="pswd"
   export POSTGRES_DB="db"
   export EDNA_LOGGING="nothing"
+  export EDNA_MDE_HOST="https://mde.edna"
 
   run edna-server --dump-config
 
@@ -207,6 +211,7 @@ function teardown() {
   assert_line --index 9 "  conn-string: host=/run/postgresql dbname=edna host=127.0.0.13 port=1234 dbname=db"
   assert_line --index 10 "    user=test password=pswd"
   assert_line --index 11 "  max-connections: 3"
+  assert_line --index 12 "mde-host: https://mde.edna"
 }
 
 @test "CLAs has higher priority then envs" {
@@ -221,6 +226,7 @@ function teardown() {
   export POSTGRES_PASSWORD="pswd"
   export POSTGRES_DB="db"
   export EDNA_LOGGING="nothing"
+  export EDNA_MDE_HOST="https://mde.edna"
 
   run edna-server --listen-addr "127.0.0.1:80" \
                   --serve-docs \
@@ -229,6 +235,7 @@ function teardown() {
                   --init-mode "enable" \
                   --init-script "/init.sql" \
                   --logging dev \
+                  --mde-host "https://mde.edna/list" \
                   --dump-config
 
   assert_success
@@ -243,4 +250,5 @@ function teardown() {
   assert_line --index 9 "  conn-string: host=/run/postgresql dbname=edna host=127.0.0.13 port=1234 dbname=db"
   assert_line --index 10 "    user=test password=pswd host=localhost dbname=edna"
   assert_line --index 11 "  max-connections: 1"
+  assert_line --index 12 "mde-host: https://mde.edna/list"
 }

--- a/backend/src/Edna/Config/CLA.hs
+++ b/backend/src/Edna/Config/CLA.hs
@@ -14,7 +14,7 @@ import Options.Applicative
   (Parser, ParserInfo, auto, eitherReader, flag', fullDesc, help, helper, info, long, metavar,
   option, progDesc, short, str, strOption, switch)
 
-import Edna.Config.Definition (LoggingConfig(..), parseLoggingConfig)
+import Edna.Config.Definition (LoggingConfig(..), MdeHost, parseLoggingConfig)
 import Edna.Util (ConnString(..), DatabaseInitOption, NetworkAddress, parseDatabaseInitOption)
 
 ednaOpts :: ParserInfo EdnaOptions
@@ -31,6 +31,7 @@ data EdnaOptions = EdnaOptions
   , eoDbInitialisationInitScript :: Maybe FilePath
   , eoLogging :: Maybe LoggingConfig
   , eoDumpConfig :: Bool
+  , eoMdeHost :: Maybe MdeHost
   } deriving stock (Generic, Show)
 
 
@@ -45,6 +46,7 @@ ednaOptsParser = EdnaOptions
   <*> dbInitialisationInitScriptParser
   <*> loggingParser
   <*> dumpConfigParser
+  <*> mdeHostParser
 
 
 configParser :: Parser (Maybe FilePath)
@@ -106,3 +108,9 @@ dumpConfigParser :: Parser Bool
 dumpConfigParser = switch $
   long "dump-config" <>
   help "Dump config and exit."
+
+mdeHostParser :: Parser (Maybe MdeHost)
+mdeHostParser = optional $ strOption $
+  long "mde-host" <>
+  metavar "EDNA_MDE_HOST" <>
+  help "Compound storage host to generate MDe links."

--- a/backend/src/Edna/Config/Definition.hs
+++ b/backend/src/Edna/Config/Definition.hs
@@ -14,6 +14,7 @@ module Edna.Config.Definition
   , ecApi
   , ecDb
   , ecLogging
+  , ecMdeHost
 
   , ApiConfig (..)
   , acListenAddr
@@ -30,6 +31,8 @@ module Edna.Config.Definition
 
   , LoggingConfig (..)
   , parseLoggingConfig
+
+  , MdeHost
   ) where
 
 import Universum
@@ -69,6 +72,8 @@ data LoggingConfig =
   -- ^ No logging.
   deriving stock (Generic, Show, Eq)
 
+type MdeHost = Text
+
 -- | Parse LoggingConfig
 parseLoggingConfig :: e -> String -> Either e LoggingConfig
 parseLoggingConfig err p =
@@ -101,6 +106,7 @@ data EdnaConfig = EdnaConfig
   { _ecApi :: ApiConfig
   , _ecDb :: DbConfig
   , _ecLogging :: LoggingConfig
+  , _ecMdeHost :: Maybe MdeHost
   } deriving stock (Generic, Show)
 
 defaultEdnaConfig :: EdnaConfig
@@ -115,6 +121,7 @@ defaultEdnaConfig = EdnaConfig
     , _dbInitialisation = Nothing
     }
   , _ecLogging = LogProd
+  , _ecMdeHost = Nothing
   }
 
 ---------------------------------------------------------------------------

--- a/backend/src/Edna/Config/Prepare.hs
+++ b/backend/src/Edna/Config/Prepare.hs
@@ -12,10 +12,11 @@ import qualified Data.Yaml as Y
 
 import Edna.Config.CLA (EdnaOptions(..))
 import Edna.Config.Definition
-  (ApiConfig(..), DbConfig(..), DbInit(..), EdnaConfig(..), LoggingConfig, defaultEdnaConfig)
+  (ApiConfig(..), DbConfig(..), DbInit(..), EdnaConfig(..), LoggingConfig, MdeHost,
+  defaultEdnaConfig)
 import Edna.Config.Environment
   (apiListenAddrEnv, apiServeDocsEnv, dbConnStringEnv, dbInitialisationInitScriptEnv,
-  dbInitialisationModeEnv, dbMaxConnectionsEnv, loggingEnv)
+  dbInitialisationModeEnv, dbMaxConnectionsEnv, loggingEnv, mdeHostEnv)
 
 choose :: a -> Maybe a -> IO (Maybe a) -> IO a
 choose _ (Just claOption) _ = return claOption
@@ -47,8 +48,9 @@ prepareConfig options = do
   api <- prepareApiConfig (_ecApi config) options
   db <- prepareDbConfig (_ecDb config) options
   logging <- prepareLoggingConfig (_ecLogging config) options
+  mdeHost <- prepareMdeHostConfig (_ecMdeHost config) options
 
-  return $ EdnaConfig api db logging
+  return $ EdnaConfig api db logging mdeHost
 
 
 prepareApiConfig :: ApiConfig -> EdnaOptions -> IO ApiConfig
@@ -101,3 +103,10 @@ prepareDbInitConfig Nothing options = do
 prepareLoggingConfig :: LoggingConfig -> EdnaOptions -> IO LoggingConfig
 prepareLoggingConfig config options = do
   choose config (eoLogging options) loggingEnv
+
+
+prepareMdeHostConfig :: Maybe MdeHost -> EdnaOptions -> IO (Maybe MdeHost)
+prepareMdeHostConfig (Just config) options =
+  Just <$> choose config (eoMdeHost options) mdeHostEnv
+prepareMdeHostConfig Nothing options =
+  chooseMaybe (eoMdeHost options) mdeHostEnv

--- a/deployment/.env
+++ b/deployment/.env
@@ -20,6 +20,8 @@ EDNA_DB_INITIALISATION_MODE="enable"
 EDNA_DB_INITIALISATION_INIT_SCRIPT="/init.sql"
 EDNA_DB_DEBUG=false
 EDNA_LOGGING="dev"
+# Note that this is stub and you should set your compound storage host
+EDNA_MDE_HOST="https://mde.edna/list"
 
 # frontend container
 FRONTEND_PORT=8080

--- a/deployment/config.yaml
+++ b/deployment/config.yaml
@@ -25,3 +25,6 @@ db:
 
 # Other possible values: "prod" and "nothing".
 logging: "dev"
+
+# Note that this is stub and you should set here your compound storage host
+mde-host: "https://mde.edna/list"

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - EDNA_DB_INITIALISATION_INIT_SCRIPT=${EDNA_DB_INITIALISATION_INIT_SCRIPT}
       - EDNA_DB_DEBUG=${EDNA_DB_DEBUG}
       - EDNA_LOGGING=${EDNA_LOGGING}
+      - EDNA_MDE_HOST=${EDNA_MDE_HOST}
 
   frontend:
     image: "ghcr.io/serokell/edna-frontend:latest"


### PR DESCRIPTION
Problem:
Currently we are generating stub MDe links. In practice they should look like https://HOST/list/27 where 27 is the number of compound.
While normally compounds are called CN<number (e. g. CN27), some compounds have more complex names (like CN27-ab.cde:1). But its not clean how to generate links for them.

Solution:
Store optional MDe link for each compound on backend and make it possible to manually edit it, just like we do it for ChemSoft links.
If no link is provided, we should do the following:
- for CN<number> use <number> as part of link
- for compound names in different format we'll just show that the link is not known.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-117

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
