### PR TITLE
[EDNA-130] Add an optimized getter of filtered experiments 

### DIFF
--- a/backend/src/Edna/DB/Integration.hs
+++ b/backend/src/Edna/DB/Integration.hs
@@ -15,10 +15,12 @@ module Edna.DB.Integration
   , runDeleteReturningList'
   , runSelectReturningOne'
   , runSelectReturningList'
+  , runSelectReturningSet
   ) where
 
 import Universum
 
+import qualified Data.Set as Set
 import qualified Database.Beam.Postgres.Conduit as C
 
 import Database.Beam.Backend.SQL.BeamExtensions (runInsertReturningList)
@@ -96,3 +98,10 @@ runSelectReturningOne' = runPg . runSelectReturningOne
 
 runSelectReturningList' :: FromBackendRow Postgres a => SqlSelect Postgres a -> Edna [a]
 runSelectReturningList' = runPg . runSelectReturningList
+
+-- | Run @SELECT@ and convert its result into a set. Conversion happens in Haskell.
+-- Note that all duplicates are silently removed and items are sorted.
+runSelectReturningSet ::
+  (Ord a, FromBackendRow Postgres a) =>
+  SqlSelect Postgres a -> Edna (Set a)
+runSelectReturningSet = fmap Set.fromList . runSelectReturningList'

--- a/backend/src/Edna/Dashboard/Web/API.hs
+++ b/backend/src/Edna/Dashboard/Web/API.hs
@@ -23,8 +23,8 @@ import Servant.Util (PaginationParams, SortingParamsOf)
 import Edna.Analysis.FourPL (AnalysisResult)
 import Edna.Dashboard.Service
   (analyseNewSubExperiment, deleteSubExperiment, getExperimentFile, getExperimentMetadata,
-  getExperiments, getMeasurements, getSubExperiment, makePrimarySubExperiment, newSubExperiment,
-  setIsSuspiciousSubExperiment, setNameSubExperiment)
+  getExperiments, getExperimentsSummary, getMeasurements, getSubExperiment,
+  makePrimarySubExperiment, newSubExperiment, setIsSuspiciousSubExperiment, setNameSubExperiment)
 import Edna.Dashboard.Web.Types
 import Edna.Setup (Edna)
 import Edna.Util (CompoundId, ExperimentId, IdType(..), ProjectId, SubExperimentId, TargetId)
@@ -96,6 +96,16 @@ data DashboardEndpoints route = DashboardEndpoints
       :> PaginationParams
       :> Get '[JSON] ExperimentsResp
 
+  , -- | Get summary of all experiments
+    deGetExperimentsSummary :: route
+      :- "experiments"
+      :> "summary"
+      :> Summary "Get summary of all experiments"
+      :> QueryParam "projectId" ProjectId
+      :> QueryParam "compoundId" CompoundId
+      :> QueryParam "targetId" TargetId
+      :> Get '[JSON] ExperimentsSummaryResp
+
   , -- | Get experiment's metadata by ID
     deGetExperimentMetadata :: route
       :- "experiment"
@@ -140,6 +150,7 @@ dashboardEndpoints = genericServerT DashboardEndpoints
   , deNewSubExp = newSubExperiment
   , deAnalyseNewSubExp = fmap snd ... analyseNewSubExperiment
   , deGetExperiments = getExperiments
+  , deGetExperimentsSummary = getExperimentsSummary
   , deGetExperimentMetadata = getExperimentMetadata
   , deGetExperimentFile = \i -> getExperimentFile i <&>
       \(name, blob) -> addHeader ("attachment;filename=" <> name) blob

--- a/backend/src/Edna/Dashboard/Web/API.hs
+++ b/backend/src/Edna/Dashboard/Web/API.hs
@@ -22,13 +22,13 @@ import Servant.Util (PaginationParams, SortingParamsOf)
 
 import Edna.Analysis.FourPL (AnalysisResult)
 import Edna.Dashboard.Service
-  (analyseNewSubExperiment, deleteSubExperiment, getExperimentFile, getExperimentMetadata,
-  getExperiments, getExperimentsSummary, getMeasurements, getSubExperiment,
+  (analyseNewSubExperiment, deleteSubExperiment, getActiveProjectNames, getExperimentFile,
+  getExperimentMetadata, getExperiments, getExperimentsSummary, getMeasurements, getSubExperiment,
   makePrimarySubExperiment, newSubExperiment, setIsSuspiciousSubExperiment, setNameSubExperiment)
 import Edna.Dashboard.Web.Types
 import Edna.Setup (Edna)
 import Edna.Util (CompoundId, ExperimentId, IdType(..), ProjectId, SubExperimentId, TargetId)
-import Edna.Web.Types (WithId)
+import Edna.Web.Types (NamesSet(..), WithId)
 
 -- | Endpoints related to projects.
 data DashboardEndpoints route = DashboardEndpoints
@@ -137,6 +137,14 @@ data DashboardEndpoints route = DashboardEndpoints
       :> Capture "subExperimentId" SubExperimentId
       :> "measurements"
       :> Get '[JSON] [WithId 'MeasurementId MeasurementResp]
+
+  , -- | Get names of all projects with experiments.
+    deGetActiveProjectNames :: route
+      :- "projects"
+      :> "names"
+      :> "active"
+      :> Summary "Get names of all projects with experiments"
+      :> Get '[JSON] NamesSet
   } deriving stock (Generic)
 
 type DashboardAPI = ToServant DashboardEndpoints AsApi
@@ -156,4 +164,5 @@ dashboardEndpoints = genericServerT DashboardEndpoints
       \(name, blob) -> addHeader ("attachment;filename=" <> name) blob
   , deGetSubExperiment = getSubExperiment
   , deGetMeasurements = getMeasurements
+  , deGetActiveProjectNames = NamesSet <$> getActiveProjectNames
   }

--- a/backend/src/Edna/Dashboard/Web/Types.hs
+++ b/backend/src/Edna/Dashboard/Web/Types.hs
@@ -30,8 +30,8 @@ import Servant.Util.Combinators.Logging (ForResponseLog(..), buildForResponse, b
 
 import Edna.Analysis.FourPL (AnalysisResult)
 import Edna.Util
-  (CompoundId, IdType(..), MeasurementId, MethodologyId, ProjectId, SubExperimentId, TargetId,
-  ednaAesonWebOptions, gDeclareNamedSchema, unSqlId)
+  (BuildableResponseLog(..), CompoundId, IdType(..), MeasurementId, MethodologyId, ProjectId,
+  SubExperimentId, TargetId, ednaAesonWebOptions, gDeclareNamedSchema, unSqlId)
 import Edna.Web.Types (WithId)
 
 -- | Data submitted in body to create a new sub-experiment.
@@ -134,13 +134,6 @@ data ExperimentsSummaryResp = ExperimentsSummaryResp
 
 instance Buildable ExperimentsSummaryResp where
   build = genericF
-
--- | Temporary newtype we use to provide @instance Buildable (ForResponseLog Text)@.
--- Probably will disappear when we introduce @Name@ type.
-newtype BuildableResponseLog a = BuildableResponseLog a
-
-instance Buildable a => Buildable (ForResponseLog (BuildableResponseLog a)) where
-  build (ForResponseLog (BuildableResponseLog a)) = build a
 
 instance Buildable (ForResponseLog ExperimentsSummaryResp) where
   build (ForResponseLog (ExperimentsSummaryResp projects compounds targets)) =

--- a/backend/src/Edna/Library/DB/Query.hs
+++ b/backend/src/Edna/Library/DB/Query.hs
@@ -18,6 +18,7 @@ module Edna.Library.DB.Query
   , getMethodologyById
   , getMethodologyByName
   , getMethodologies
+  , getMethodologyNames
   , deleteMethodology
   , insertMethodology
   , updateMethodology
@@ -25,6 +26,7 @@ module Edna.Library.DB.Query
   , getProjectByName
   , getProjectWithCompoundsById
   , getProjectsWithCompounds
+  , getProjectNames
   , insertProject
   , updateProject
   , touchProject
@@ -254,6 +256,11 @@ getMethodology' eMethodologyId =
       fieldSort @"name" tmName .*.
       HNil
 
+-- | Get names of all methodologies in the system.
+getMethodologyNames :: Edna (Set Text)
+getMethodologyNames = runSelectReturningSet $ select $
+  tmName <$> all_ (esTestMethodology ednaSchema)
+
 -- | Insert methodology and return its DB value.
 -- Fails if methodology with this name already exists
 insertMethodology :: MethodologyReq -> Edna TestMethodologyRec
@@ -350,6 +357,11 @@ projectsWithCompounds projectIdEither =
       fieldSort @"creationDate" pCreationDate .*.
       fieldSort @"lastUpdate" pLastUpdate .*.
       HNil
+
+-- | Get names of all projects in the system.
+getProjectNames :: Edna (Set Text)
+getProjectNames = runSelectReturningSet $ select $
+  pName <$> all_ (esProject ednaSchema)
 
 -- | Insert project and return its DB value.
 -- Fails if project with this name already exists

--- a/backend/src/Edna/Library/Service.hs
+++ b/backend/src/Edna/Library/Service.hs
@@ -25,6 +25,8 @@ module Edna.Library.Service
   -- * Re-export some queries as is
   , Q.getTargetNames
   , Q.getCompoundNames
+  , Q.getMethodologyNames
+  , Q.getProjectNames
   ) where
 
 import Universum

--- a/backend/src/Edna/Library/Service.hs
+++ b/backend/src/Edna/Library/Service.hs
@@ -21,6 +21,10 @@ module Edna.Library.Service
   , getProjects
   , addProject
   , updateProject
+
+  -- * Re-export some queries as is
+  , Q.getTargetNames
+  , Q.getCompoundNames
   ) where
 
 import Universum

--- a/backend/src/Edna/Library/Web/API.hs
+++ b/backend/src/Edna/Library/Web/API.hs
@@ -31,14 +31,15 @@ import Servant.Server.Generic (AsServerT, genericServerT)
 import Servant.Util (PaginationParams, SortingParamsOf)
 
 import Edna.Library.Service
-  (addMethodology, addProject, deleteMethodology, editChemSoft, editMde, getCompound, getCompounds,
-  getMethodologies, getMethodology, getProject, getProjects, getTarget, getTargets,
-  updateMethodology, updateProject)
+  (addMethodology, addProject, deleteMethodology, editChemSoft, editMde, getCompound,
+  getCompoundNames, getCompounds, getMethodologies, getMethodology, getMethodologyNames, getProject,
+  getProjectNames, getProjects, getTarget, getTargetNames, getTargets, updateMethodology,
+  updateProject)
 import Edna.Library.Web.Types
   (CompoundResp, MethodologyReq, MethodologyResp, ProjectReq, ProjectResp, TargetResp)
 import Edna.Setup (Edna)
 import Edna.Util (IdType(..), MethodologyId, SqlId(..))
-import Edna.Web.Types (URI, WithId)
+import Edna.Web.Types (NamesSet(..), URI, WithId)
 
 -- | Endpoints related to projects.
 data ProjectEndpoints route = ProjectEndpoints
@@ -65,6 +66,13 @@ data ProjectEndpoints route = ProjectEndpoints
       :> PaginationParams
       :> Get '[JSON] [WithId 'ProjectId ProjectResp]
 
+  , -- | Get names of all known projects
+    peGetProjectNames :: route
+      :- "projects"
+      :> "names"
+      :> Summary "Get names of all known projects"
+      :> Get '[JSON] NamesSet
+
   , -- | Get project data by ID
     peGetProject :: route
       :- "project"
@@ -80,6 +88,7 @@ projectEndpoints = genericServerT ProjectEndpoints
   { peAddProject = addProject
   , peEditProject = updateProject
   , peGetProjects = getProjects
+  , peGetProjectNames = NamesSet <$> getProjectNames
   , peGetProject = getProject
   }
 
@@ -115,6 +124,13 @@ data MethodologyEndpoints route = MethodologyEndpoints
       :> PaginationParams
       :> Get '[JSON] [WithId 'MethodologyId MethodologyResp]
 
+  , -- | Get names of all known methodologies
+    meGetMethodologyNames :: route
+      :- "methodologies"
+      :> "names"
+      :> Summary "Get names of all known methodologies"
+      :> Get '[JSON] NamesSet
+
   , -- | Get methodology data by ID
     meGetMethodology :: route
       :- "methodology"
@@ -131,6 +147,7 @@ methodologyEndpoints = genericServerT MethodologyEndpoints
   , meEditMethodology = updateMethodology
   , meDeleteMethodology = deleteMethodology
   , meGetMethodologies = getMethodologies
+  , meGetMethodologyNames = NamesSet <$> getMethodologyNames
   , meGetMethodology = getMethodology
   }
 
@@ -143,6 +160,13 @@ data TargetEndpoints route = TargetEndpoints
       :> SortingParamsOf TargetResp
       :> PaginationParams
       :> Get '[JSON] [WithId 'TargetId TargetResp]
+
+  , -- | Get names of all known targets
+    teGetTargetNames :: route
+      :- "targets"
+      :> "names"
+      :> Summary "Get names of all known targets"
+      :> Get '[JSON] NamesSet
 
   , -- | Get target data by ID
     teGetTarget :: route
@@ -158,6 +182,7 @@ targetEndpoints :: ToServant TargetEndpoints (AsServerT Edna)
 targetEndpoints = genericServerT TargetEndpoints
   { teGetTargets = getTargets
   , teGetTarget = getTarget
+  , teGetTargetNames = NamesSet <$> getTargetNames
   }
 
 -- | Endpoints related to compounds.
@@ -188,6 +213,13 @@ data CompoundEndpoints route = CompoundEndpoints
       :> PaginationParams
       :> Get '[JSON] [WithId 'CompoundId CompoundResp]
 
+  , -- | Get names of all known compounds
+    ceGetCompoundNames :: route
+      :- "compounds"
+      :> "names"
+      :> Summary "Get names of all known compounds"
+      :> Get '[JSON] NamesSet
+
   , -- | Get compound data by ID
     ceGetCompound :: route
       :- "compound"
@@ -203,5 +235,6 @@ compoundEndpoints = genericServerT CompoundEndpoints
   { ceEditChemSoft = editChemSoft
   , ceEditMde = editMde
   , ceGetCompounds = getCompounds
+  , ceGetCompoundNames = NamesSet <$> getCompoundNames
   , ceGetCompound = getCompound
   }

--- a/backend/src/Edna/Util.hs
+++ b/backend/src/Edna/Util.hs
@@ -10,6 +10,7 @@ module Edna.Util
   , ExperimentFileId
   , ExperimentId
   , Host
+  , BuildableResponseLog (..)
   , IdType (..)
   , MeasurementId
   , MethodologyId
@@ -57,7 +58,7 @@ import Database.Beam.Backend (SqlSerial(..))
 import Fmt (Buildable(..), Builder, pretty, (+|), (|+))
 import qualified GHC.Generics as G
 import Servant (FromHttpApiData(..))
-import Servant.Util.Combinators.Logging (ForResponseLog, buildForResponse)
+import Servant.Util.Combinators.Logging (ForResponseLog(..), buildForResponse)
 import qualified Text.ParserCombinators.ReadP as ReadP
 import Text.Read (Read(..), read)
 import qualified Text.Show
@@ -234,6 +235,13 @@ uncurry3 f (a, b, c) = f a b c
 -- (avoiding cyclic dependencies).
 logUnconditionally :: MonadIO m => Text -> m ()
 logUnconditionally msg = hPutStr stderr (msg <> "\n")
+
+-- | Temporary newtype we use to provide @instance Buildable (ForResponseLog Text)@.
+-- Probably will disappear when we introduce @Name@ type.
+newtype BuildableResponseLog a = BuildableResponseLog a
+
+instance Buildable a => Buildable (ForResponseLog (BuildableResponseLog a)) where
+  build (ForResponseLog (BuildableResponseLog a)) = build a
 
 ----------------
 -- SqlId

--- a/backend/src/Edna/Web/Types.hs
+++ b/backend/src/Edna/Web/Types.hs
@@ -4,11 +4,15 @@
 
 -- | Legacy module that currently defines only 'WithId' type and should probably
 -- be changed somehow.
+-- UPD: now it has not only 'WithId', but it should be revised anyway, see EDNA-125.
 
 {-# LANGUAGE OverloadedLists #-}
+-- https://github.com/serokell/universum/issues/208
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 module Edna.Web.Types
   ( WithId (..)
+  , NamesSet (..)
 
   -- * Re-exported for convenience
   , URI (..)
@@ -16,6 +20,7 @@ module Edna.Web.Types
 
 import Universum
 
+import Data.Aeson (ToJSON)
 import Data.Aeson.TH (deriveToJSON)
 import Data.Swagger (SwaggerType(..), ToSchema(..), declareSchemaRef, properties, required, type_)
 import Data.Swagger.Internal.Schema (unnamed)
@@ -25,7 +30,7 @@ import Network.URI (URI(..))
 import Network.URI.JSON ()
 import Servant.Util.Combinators.Logging (ForResponseLog(..), buildForResponse, buildListForResponse)
 
-import Edna.Util (SqlId(..), ednaAesonWebOptions)
+import Edna.Util (BuildableResponseLog(..), SqlId(..), ednaAesonWebOptions)
 
 ----------------
 -- General types
@@ -45,6 +50,20 @@ instance Buildable t => Buildable (ForResponseLog (WithId k t)) where
 
 instance Buildable t => Buildable (ForResponseLog [WithId k t]) where
   build = buildListForResponse (take 5)
+
+-- | Set of names of some entities.
+--
+-- For now the primary reason to have this type is to define 'Buildable' for it
+-- wrapped into 'ForResponseLog'.
+newtype NamesSet = NamesSet
+  { unNamesSet :: Set Text
+  } deriving stock (Show)
+    deriving newtype (Eq, ToJSON, ToSchema, Container)
+
+instance Buildable (ForResponseLog NamesSet) where
+  build (ForResponseLog names) =
+    buildListForResponse (take 10)
+    (ForResponseLog . map BuildableResponseLog . toList $ names)
 
 ----------------
 -- JSON

--- a/backend/test/Test/Gen.hs
+++ b/backend/test/Test/Gen.hs
@@ -85,6 +85,10 @@ genWithId genT = WithId <$> genSqlId <*> genT
 genName :: MonadGen m => m Text
 genName = Gen.text (Range.linear 1 30) Gen.unicode
 
+genNamesSet :: MonadGen m => m NamesSet
+genNamesSet = NamesSet . Set.fromList <$>
+  Gen.list (Range.linear 0 5) (Gen.text (Range.linear 1 30) Gen.unicode)
+
 genDescription :: MonadGen m => m Text
 genDescription = Gen.text (Range.linear 5 200) Gen.unicode
 
@@ -285,6 +289,9 @@ deriving newtype instance Arbitrary (SqlId t)
 
 instance Arbitrary t => Arbitrary (WithId k t) where
   arbitrary = hedgehog $ genWithId HQC.arbitrary
+
+instance Arbitrary NamesSet where
+  arbitrary = hedgehog genNamesSet
 
 instance Arbitrary URI where
   arbitrary = hedgehog genURI

--- a/backend/test/Test/Gen.hs
+++ b/backend/test/Test/Gen.hs
@@ -25,6 +25,7 @@ module Test.Gen
   , genCompoundResp
   , genTargetResp
   , genExperimentsResp
+  , genExperimentsSummaryResp
   , genExperimentResp
   , genSubExperimentResp
   , genMeasurementResp
@@ -46,6 +47,7 @@ import Universum
 
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.HashSet as HS
+import qualified Data.Set as Set
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Gen.QuickCheck as HQC
 import qualified Hedgehog.Range as Range
@@ -166,6 +168,14 @@ genNewSubExperimentReq =
 genExperimentsResp :: MonadGen m => m ExperimentsResp
 genExperimentsResp =
   ExperimentsResp <$> Gen.list (Range.linear 0 5) (genWithId genExperimentResp)
+
+genExperimentsSummaryResp :: MonadGen m => m ExperimentsSummaryResp
+genExperimentsSummaryResp = do
+  let genNames = Set.fromList <$> Gen.list (Range.linear 0 10) genName
+  esrMatchedProjects <- genNames
+  esrMatchedCompounds <- genNames
+  esrMatchedTargets <- genNames
+  return ExperimentsSummaryResp {..}
 
 genExperimentResp :: MonadGen m => m ExperimentResp
 genExperimentResp = do
@@ -313,6 +323,9 @@ instance Arbitrary NewSubExperimentReq where
 
 instance Arbitrary ExperimentsResp where
   arbitrary = hedgehog genExperimentsResp
+
+instance Arbitrary ExperimentsSummaryResp where
+  arbitrary = hedgehog genExperimentsSummaryResp
 
 instance Arbitrary ExperimentResp where
   arbitrary = hedgehog genExperimentResp

--- a/backend/test/Test/LibrarySpec.hs
+++ b/backend/test/Test/LibrarySpec.hs
@@ -22,9 +22,9 @@ import Test.Hspec
 
 import Edna.Library.Error (LibraryError(..))
 import Edna.Library.Service
-  (addMethodology, addProject, deleteMethodology, editChemSoft, editMde, getCompound, getCompounds,
-  getMethodologies, getMethodology, getProject, getProjects, getTarget, getTargets,
-  updateMethodology, updateProject)
+  (addMethodology, addProject, deleteMethodology, editChemSoft, editMde, getCompound,
+  getCompoundNames, getCompounds, getMethodologies, getMethodology, getProject, getProjects,
+  getTarget, getTargetNames, getTargets, updateMethodology, updateProject)
 import Edna.Library.Web.Types
   (CompoundResp(..), MethodologyReq(..), MethodologyResp(..), ProjectReq(..), ProjectResp(..),
   TargetResp(..))
@@ -82,6 +82,11 @@ gettersSpec = do
       -- have equal addition date, but different IDs
       checkTargets (Just (compare `on` (Down . view _1))) (Just paginationDesc) targetsDescDate
 
+  describe "getTargetNames" $ do
+    it "successfully gets names of all targets" $ runTestEdna $ do
+      names <- getTargetNames
+      liftIO $ toList names `shouldBe` map (view $ _2 . _1) allExpectedTargets
+
   describe "getCompound" $ do
     it "successfully gets known compounds one by one" $ runTestEdna $ do
       compounds <- mapM getCompound compoundIds
@@ -103,6 +108,11 @@ gettersSpec = do
       compoundsDesc <- getCompounds (mkSortingSpec [desc #name])
         (mkPagination paginationDesc)
       checkCompounds (Just (compare `on` (Down . snd))) (Just paginationDesc) compoundsDesc
+
+  describe "getCompoundNames" $ do
+    it "successfully gets names of all compounds" $ runTestEdna $ do
+      names <- getCompoundNames
+      liftIO $ toList names `shouldBe` map snd allExpectedCompounds
 
   describe "getMethodology" $ do
     it "successfully gets known methodologies one by one" $ runTestEdna $ do


### PR DESCRIPTION
## Description

In order to construct dashboard selectors we use the `/experiments` endpoint which sends a lot of data, especially if you pass no filters (which happens for example if you open dashboard from scratch and it has no filters). So we add another endpoint which returns only data about experiments necessary to construct dashboard selectors. Additionally, we add endpoints to query names of all projects, compounds, etc. because they work faster than `/projects`, `/compounds`, etc.

It's ready, but I want to add more tests/improve existing ones.

## Related issue(s)


Resolves https://issues.serokell.io/issue/EDNA-130

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
