### PR TITLE
[EDNA-135] Add getter of number of experiments

### DIFF
--- a/backend/src/Edna/Dashboard/Service.hs
+++ b/backend/src/Edna/Dashboard/Service.hs
@@ -12,6 +12,7 @@ module Edna.Dashboard.Service
   , deleteSubExperiment
   , newSubExperiment
   , analyseNewSubExperiment
+  , Q.getExperimentsNumber
   , getExperiments
   , getExperimentsSummary
   , getActiveProjectNames

--- a/backend/src/Edna/Dashboard/Web/API.hs
+++ b/backend/src/Edna/Dashboard/Web/API.hs
@@ -23,8 +23,9 @@ import Servant.Util (PaginationParams, SortingParamsOf)
 import Edna.Analysis.FourPL (AnalysisResult)
 import Edna.Dashboard.Service
   (analyseNewSubExperiment, deleteSubExperiment, getActiveProjectNames, getExperimentFile,
-  getExperimentMetadata, getExperiments, getExperimentsSummary, getMeasurements, getSubExperiment,
-  makePrimarySubExperiment, newSubExperiment, setIsSuspiciousSubExperiment, setNameSubExperiment)
+  getExperimentMetadata, getExperiments, getExperimentsNumber, getExperimentsSummary,
+  getMeasurements, getSubExperiment, makePrimarySubExperiment, newSubExperiment,
+  setIsSuspiciousSubExperiment, setNameSubExperiment)
 import Edna.Dashboard.Web.Types
 import Edna.Setup (Edna)
 import Edna.Util (CompoundId, ExperimentId, IdType(..), ProjectId, SubExperimentId, TargetId)
@@ -83,6 +84,16 @@ data DashboardEndpoints route = DashboardEndpoints
       :> "analyse"
       :> ReqBody '[JSON] NewSubExperimentReq
       :> Post '[JSON] AnalysisResult
+
+  , -- | Get total number of experiments matching optional filters
+    deGetExperimentsNumber :: route
+      :- "experiments"
+      :> "number"
+      :> Summary "Get total number of experiments matching optional filters"
+      :> QueryParam "projectId" ProjectId
+      :> QueryParam "compoundId" CompoundId
+      :> QueryParam "targetId" TargetId
+      :> Get '[JSON] Word32
 
   , -- | Get known experiments with optional pagination and sorting
     deGetExperiments :: route
@@ -157,6 +168,7 @@ dashboardEndpoints = genericServerT DashboardEndpoints
   , deDeleteSubExp = deleteSubExperiment
   , deNewSubExp = newSubExperiment
   , deAnalyseNewSubExp = fmap snd ... analyseNewSubExperiment
+  , deGetExperimentsNumber = getExperimentsNumber
   , deGetExperiments = getExperiments
   , deGetExperimentsSummary = getExperimentsSummary
   , deGetExperimentMetadata = getExperimentMetadata

--- a/backend/src/Edna/Orphans.hs
+++ b/backend/src/Edna/Orphans.hs
@@ -10,10 +10,11 @@ module Edna.Orphans () where
 
 import Universum
 
+import Fmt (Buildable(..))
 import Lens.Micro.Internal (Field1(..))
 import RIO (RIO(..))
 import Servant.Multipart (MultipartForm')
-import Servant.Util.Combinators.Logging (ApiCanLogArg)
+import Servant.Util.Combinators.Logging (ApiCanLogArg, ForResponseLog(..), buildForResponse)
 import Servant.Util.Common.Common (ApiHasArgClass(..))
 
 -- It's also available in @rio-orphans@, but that would add extra dependencies,
@@ -29,6 +30,16 @@ instance ApiHasArgClass (MultipartForm' mods tag t) where
   apiArgName _ = "multipart"
 
 instance ApiCanLogArg (MultipartForm' mods tag t)
+
+-- 'ForResponseLog' wrapper is supposed to hide sensitive information from being
+-- printed. 'Word32' has 32 bits (or less) and thus is not suitable for
+-- sensitive information.
+instance Buildable (ForResponseLog Word32) where
+  build = buildForResponse
+
+----------------
+-- Other
+----------------
 
 -- defined the same way as in @Lens.Micro.Internal@ (where instances are
 -- provided only for tuples with up to 5 items)


### PR DESCRIPTION
## Description

Problem: in order to implement pagination on frontend it would be
convenient to have a quick way to know the total number of experiments
to be shown in dashboard.

Solution: add `deGetExperimentsNumber` endpoint similar to
`deGetExperiments` which returns just the number of experiments
instead of experiments themselves (and lacks sorting and pagination
arguments for obvious reasons).


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves https://issues.serokell.io/issue/EDNA-135

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
