### PR TITLE
[EDNA-133] Add required license information to frontend files

### DIFF
--- a/frontend/src/components/Spinner/Spinner.scss
+++ b/frontend/src/components/Spinner/Spinner.scss
@@ -4,6 +4,15 @@
  * SPDX-License-Identifier: MIT
  */
 
+/*!
+ *  License
+ *  ------------------------------------------------------------------------------
+ *  This code is licensed under the MIT License.
+ *  The license is available at:
+ *  https://github.com/lukehaas/css-loaders/blob/bbd6d6776d89b546b6cc2e3b0675bb9b9ed1fcd6/LICENSE
+ *  Copyright (c) 2014 Luke Haas
+ */
+
 // Taken from here https://projects.lukehaas.me/css-loaders/
 /* stylelint-disable */
 .spinner,

--- a/frontend/src/styles/fonts/PTRootUI.scss
+++ b/frontend/src/styles/fonts/PTRootUI.scss
@@ -4,6 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+
+/*!
+ *  License
+ *  ------------------------------------------------------------------------------
+ *  Font Software is licensed under the SIL Open Font License, Version 1.1.
+ *  This license is available with a FAQ at: https://scripts.sil.org/OFL
+ *  Copyright (c) Paratype, with Reserved Font Name "PT Root UI".
+ */
 @font-face {
   font-family: "PT Root UI";
   font-style: normal;


### PR DESCRIPTION
## Description

Problem: there are some frontend files that we copy-pasted from
    somewhere. Their licenses require us to include their copyright notice
    and license text, but we don't include them yet. Specifically, these
    files are: `Spinner.scss` style and all PTRootUI fonts.
    
Solution:
1. Refer to the MIT license in `Spinner.scss`.
2. License information about fonts is included into `PTRootUI.scss`
    file where the fonts are imported. It seems to be a common approach
    permitted by the OFL license and.
    
Note that we use `/*!` comments, so they are not removed in production mode.

I am not sure whether providing these links is enough. I can copy whole texts of licenses, I just find it a bit ugly.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-133

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
