### PR TITLE
Reset button for upload status and upload page improvements

### DIFF
--- a/frontend/src/assets/svg/delete-stroke.svg
+++ b/frontend/src/assets/svg/delete-stroke.svg
@@ -1,0 +1,6 @@
+<svg width="25" height="23" viewBox="0 0 25 23" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.23354 20.7782L5.60145 4.51172H19.4164L17.7843 20.7782C17.733 21.2893 17.3029 21.6784 16.7893 21.6784H8.22855C7.71492 21.6784 7.28482 21.2893 7.23354 20.7782Z" stroke="#CACACA" stroke-width="2"/>
+<line x1="3.88477" y1="4.42383" x2="21.1155" y2="4.42383" stroke="#CACACA" stroke-width="2" stroke-linecap="round"/>
+<line x1="7" y1="14" x2="18" y2="14" stroke="#CACACA" stroke-width="2" stroke-linecap="round"/>
+<rect x="8.69922" y="1.31836" width="7.61539" height="3.10612" rx="1" stroke="#CACACA" stroke-width="2"/>
+</svg>

--- a/frontend/src/components/Button/Button.scss
+++ b/frontend/src/components/Button/Button.scss
@@ -39,7 +39,7 @@
 
   position: relative;
   display: flex;
-  padding: (16 * $px) (22 * $px);
+  padding: (16 * $px) (36 * $px);
   color: white;
   background-color: $color-green;
   border: 0;
@@ -115,15 +115,15 @@
 
 .roundedButton {
   @include snd-btn;
-  padding: (10 * $px) (21 * $px);
-  font-size: 14 * $px;
 
+  padding: (10 * $px) (20 * $px) (10 * $px) (25 * $px);
+  font-size: 14 * $px;
   font-weight: 700;
   line-height: 18 * $px;
   color: $color-green;
   background-color: $color-light-green;
   border: 0;
-  border-radius: 50 * $px;
+  border-radius: 6 * $px;
 
   &:hover {
     background-color: #def4e9;

--- a/frontend/src/components/UploadStatus/UploadStatus.scss
+++ b/frontend/src/components/UploadStatus/UploadStatus.scss
@@ -30,8 +30,35 @@
     align-items: center;
     font-size: 14 * $px;
     font-style: normal;
-    font-weight: 600;
+    font-weight: 400;
     line-height: 17 * $px;
+  }
+
+  &__statusIcons {
+    display: flex;
+    align-items: center;
+  }
+
+  &__statusIcon {
+    padding-right: 1.875rem;
+    border-right: $px solid #9ba5a1;
+  }
+
+  &__resetIcon {
+    margin-left: 1.875rem;
+
+    &:hover {
+      svg {
+        /* stylelint-disable */
+        rect {
+          stroke: #ce6c6c;
+        }
+
+        path {
+          stroke: #ce6c6c;
+        }
+      }
+    }
   }
 }
 
@@ -43,19 +70,19 @@
     margin-bottom: 6 * $px;
     font-size: 10 * $px;
     line-height: 12 * $px;
-    color: #616161;
+    color: #9ba5a1;
   }
 
   &__bar {
     width: 100%;
     height: 2 * $px;
-    background-color: #eee;
+    background-color: #bdddd5;
     border-radius: $bar-radius;
   }
 
   &__progress {
     height: 100%;
-    background-color: #ccc;
+    background-color: #3a8370;
     border-radius: $bar-radius;
   }
 }

--- a/frontend/src/components/UploadStatus/UploadStatus.tsx
+++ b/frontend/src/components/UploadStatus/UploadStatus.tsx
@@ -3,14 +3,20 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import React from "react";
-import { useRecoilValue } from "recoil";
-import SuccCheckmark from "../../assets/svg/success-checkmark.svg";
+import { useRecoilState } from "recoil";
+import { Tooltip } from "../Tooltip/Tooltip";
+import SuccCheckmark from "../../assets/svg/success-notify.svg";
 import FailedIcon from "../../assets/svg/failed.svg";
+import ResetCheckmark from "../../assets/svg/delete-stroke.svg";
 import { excelFileAtom } from "../../store/atoms";
 import "./UploadStatus.scss";
+import { Button } from "../Button/Button";
+import { isAdded } from "../../store/types";
+import { useNotificationListUpdater } from "../../store/updaters";
 
 export function UploadStatus(): React.ReactElement {
-  const uploadState = useRecoilValue(excelFileAtom);
+  const [uploadState, setExcelFile] = useRecoilState(excelFileAtom);
+  const notificationsUpdater = useNotificationListUpdater();
 
   return uploadState ? (
     <div className="uploadStatus">
@@ -18,8 +24,6 @@ export function UploadStatus(): React.ReactElement {
         <span className="uploadStatus__label">
           {uploadState.state === "uploading"
             ? "Uploading..."
-            : uploadState.state === "verifying"
-            ? "Verifying"
             : uploadState.state === "parsed"
             ? "Parsed"
             : uploadState.state === "failed-to-add"
@@ -28,7 +32,44 @@ export function UploadStatus(): React.ReactElement {
             ? "Added"
             : ""}
         </span>
-        {uploadState.state === "parsed" && <SuccCheckmark />}
+        {(uploadState.state === "parsed" || uploadState.state === "added") && (
+          <div className="uploadStatus__statusIcons">
+            <div className="uploadStatus__statusIcon">
+              <SuccCheckmark />
+            </div>
+            <div
+              className="uploadStatus__resetIcon"
+              onClick={() => {
+                setExcelFile(undefined);
+                if (!isAdded(uploadState)) {
+                  notificationsUpdater({
+                    type: "Add",
+                    notificationType: "Error",
+                    element: manualRemove => (
+                      <div className="uploadingForm__resetNotify">
+                        <span>You have reset the file</span>
+                        <Button
+                          type="text"
+                          className="uploadingForm__resetNotifyBtn"
+                          onClick={() => {
+                            setExcelFile(uploadState);
+                            manualRemove();
+                          }}
+                        >
+                          Undo
+                        </Button>
+                      </div>
+                    ),
+                  });
+                }
+              }}
+            >
+              <Tooltip text="Clear file field">
+                <ResetCheckmark />
+              </Tooltip>
+            </div>
+          </div>
+        )}
         {uploadState.state === "failed-to-add" && <FailedIcon />}
       </div>
       {uploadState.state === "uploading" && <ProgressBar percent={uploadState.progress} />}

--- a/frontend/src/pages/upload/UploadPage.scss
+++ b/frontend/src/pages/upload/UploadPage.scss
@@ -22,6 +22,7 @@
     grid-row: 1/2;
     grid-column: 1/2;
     margin-bottom: 32 * $px;
+    color: #3a8370;
   }
 
   &__uploadAddButtons {
@@ -95,6 +96,7 @@
   &__resetNotify {
     display: flex;
     align-items: center;
+    justify-content: space-between;
   }
 
   &__resetNotifyBtn {

--- a/frontend/src/pages/upload/UploadPage.tsx
+++ b/frontend/src/pages/upload/UploadPage.tsx
@@ -211,28 +211,30 @@ export const UploadPage: FunctionComponent = (): ReactElement => {
                   setHasUnsavedFields(false);
                   setExcelFile(undefined);
                   resetForm();
-                  notificationsUpdater({
-                    type: "Add",
-                    notificationType: "Error",
-                    element: manualRemove => (
-                      <div className="uploadingForm__resetNotify">
-                        <span>You have reset all completed fields</span>
-                        <Button
-                          type="text"
-                          className="uploadingForm__resetNotifyBtn"
-                          disabled={!isAdded(excelFile) && !hasUnsavedFields}
-                          onClick={() => {
-                            setHasUnsavedFields(true);
-                            setValues(values);
-                            setExcelFile(excelFile);
-                            manualRemove();
-                          }}
-                        >
-                          Undo
-                        </Button>
-                      </div>
-                    ),
-                  });
+                  if (!isAdded(excelFile)) {
+                    notificationsUpdater({
+                      type: "Add",
+                      notificationType: "Error",
+                      element: manualRemove => (
+                        <div className="uploadingForm__resetNotify">
+                          <span>You have reset all completed fields</span>
+                          <Button
+                            type="text"
+                            className="uploadingForm__resetNotifyBtn"
+                            disabled={!isAdded(excelFile) && !hasUnsavedFields}
+                            onClick={() => {
+                              setHasUnsavedFields(true);
+                              setValues(values);
+                              setExcelFile(excelFile);
+                              manualRemove();
+                            }}
+                          >
+                            Undo
+                          </Button>
+                        </div>
+                      ),
+                    });
+                  }
                 }}
               >
                 {isAdded(excelFile) ? "Upload another one" : "Reset"}

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -49,7 +49,6 @@ export type SuccessSubExperimentWithMeasurements = {
 export type FileUploadState =
   | undefined
   | { state: "uploading"; progress: number }
-  | { state: "verifying" }
   | { state: "parsed"; targets: ParsedExcelDto[] }
   | { state: "added"; targets: ParsedExcelDto[] }
   | { state: "failed-to-add"; reason: string };


### PR DESCRIPTION
Problem: we need a way to reset only uploaded file

Solution: after parsing of adding file there is a way now to reset the
file. Also you will see notification with undo. Additionally there are
some upload page style improvements

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-122

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
