### PR TITLE
Upload experiment spinner

### DIFF
--- a/frontend/src/components/UploadStatus/UploadStatus.tsx
+++ b/frontend/src/components/UploadStatus/UploadStatus.tsx
@@ -24,7 +24,7 @@ export function UploadStatus(): React.ReactElement {
         <span className="uploadStatus__label">
           {uploadState.state === "uploading"
             ? "Uploading..."
-            : uploadState.state === "parsed"
+            : uploadState.state === "parsed" || uploadState.state === "adding"
             ? "Parsed"
             : uploadState.state === "failed-to-add"
             ? "Failed to add"
@@ -32,7 +32,9 @@ export function UploadStatus(): React.ReactElement {
             ? "Added"
             : ""}
         </span>
-        {(uploadState.state === "parsed" || uploadState.state === "added") && (
+        {(uploadState.state === "parsed" ||
+          uploadState.state === "added" ||
+          uploadState.state === "adding") && (
           <div className="uploadStatus__statusIcons">
             <div className="uploadStatus__statusIcon">
               <SuccCheckmark />

--- a/frontend/src/pages/upload/UploadPage.scss
+++ b/frontend/src/pages/upload/UploadPage.scss
@@ -105,4 +105,19 @@
     color: rgba(#191c1c, 0.7) !important;
     border-left: $px solid #dfe3e3 !important;
   }
+
+  &__submitBtn {
+    &_spinner {
+      padding: (11 * $px) (88 * $px) !important;
+      background-color: #3a8370 !important;
+    }
+  }
+
+  &__spinner {
+    width: 33 * $px;
+    height: 33 * $px;
+    margin: 0;
+    border-color: white;
+    border-left-color: #3a8370;
+  }
 }

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -50,6 +50,7 @@ export type FileUploadState =
   | undefined
   | { state: "uploading"; progress: number }
   | { state: "parsed"; targets: ParsedExcelDto[] }
+  | { state: "adding"; targets: ParsedExcelDto[] }
   | { state: "added"; targets: ParsedExcelDto[] }
   | { state: "failed-to-add"; reason: string };
 


### PR DESCRIPTION
Problem: experiments addition may takes a lot of time and we don't
show its progress

Solution: add spinner on add experiments button when they a loading

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/EDNA-108

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
