### PR TITLE
Workaround incorrect dashboard table renderring on some platforms

### DIFF
--- a/frontend/src/pages/dashboard/SubexperimentPlate/SubexperimentPlate.scss
+++ b/frontend/src/pages/dashboard/SubexperimentPlate/SubexperimentPlate.scss
@@ -11,7 +11,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  width: 165 * $px;
+  width: 160 * $px;
   padding: (10 * $px) (16 * $px);
   cursor: default;
   border: (2 * $px) solid $color-stroke2;


### PR DESCRIPTION
## Description

Problem: sometimes sub-experiments in the dashboard table are shown
incorrectly: there is only one column with them, but the idea is to
show two of them in one row.

Solution: we couldn't find a proper solution and the exact reason
for this behavior. Moreover, it happens only on some platforms,
but doesn't happen on MacBooks and iPhone for example.
As a workaround we simply decrease the width of the sub-experiment
plate so that 2 sub-experiments fit into the width with higher
probability.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves https://issues.serokell.io/issue/EDNA-139

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

We have no infra for such tests.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
